### PR TITLE
timestamp validator

### DIFF
--- a/modules/core/src/alloy/validation/SimpleRestJsonTimestampValidator.java
+++ b/modules/core/src/alloy/validation/SimpleRestJsonTimestampValidator.java
@@ -1,0 +1,60 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.validation;
+
+import alloy.SimpleRestJsonTrait;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.neighbor.Walker;
+import software.amazon.smithy.model.neighbor.NeighborProvider;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.shapes.*;
+import software.amazon.smithy.model.traits.TimestampFormatTrait;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+public final class SimpleRestJsonTimestampValidator extends AbstractValidator {
+
+    @Override
+    public List<ValidationEvent> validate(Model model) {
+        Walker walker = new Walker(NeighborProvider.of(model));
+        Set<Shape> entryPoints = model.getShapesWithTrait(SimpleRestJsonTrait.class);
+        Stream<Shape> closure = entryPoints.stream()
+                .flatMap(restJsonService -> walker.walkShapes(restJsonService).stream());
+
+        return closure.filter(Shape::isTimestampShape)
+                .flatMap(this::validateTimestamp).collect(Collectors.toList());
+    }
+
+    private Stream<ValidationEvent> validateTimestamp(Shape shape) {
+        if (shape.isTimestampShape() && !shape.getTrait(TimestampFormatTrait.class).isPresent()) {
+            return Stream.of(warn(shape));
+        } else {
+            return Stream.empty();
+        }
+    }
+
+    private ValidationEvent warn(Shape shape) {
+        return warning(shape, "Timestamp shape " + shape.getId() + " does not have a timestamp format trait");
+    }
+
+
+}

--- a/modules/core/test/src/alloy/validation/SimpleRestJsonTimestampFormatValidatorSpec.scala
+++ b/modules/core/test/src/alloy/validation/SimpleRestJsonTimestampFormatValidatorSpec.scala
@@ -1,0 +1,72 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.validation
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes._
+import software.amazon.smithy.model.validation.Severity
+import software.amazon.smithy.model.validation.ValidationEvent
+
+import scala.jdk.CollectionConverters._
+import alloy.SimpleRestJsonTrait
+
+final class SimpleRestJsonTimestampFormatValidatorSpec extends munit.FunSuite {
+
+  test("warn when timestamp shape does not have a timestamp format trait and is reachable from a service with a rest json trait") {
+    val validator = new SimpleRestJsonTimestampValidator()
+    val timestamp = TimestampShape
+      .builder()
+      .id("test#time")
+      .build()
+    val member = MemberShape
+      .builder()
+      .id("test#struct$ts")
+      .target(timestamp.getId)
+      .build()
+    val struct =
+      StructureShape.builder().id("test#struct").addMember(member).build()
+
+    val op = OperationShape.builder().id("test#TestOp").input(struct).build()
+    val service = ServiceShape
+      .builder()
+      .id("test#TestService")
+      .version("1")
+      .addOperation(op)
+      .addTrait(new SimpleRestJsonTrait())
+      .build()
+
+    val model =
+      Model.builder().addShapes(timestamp,struct, op, service).build()
+
+
+    val result = validator.validate(model).asScala.toList
+
+    val expected = List(
+      ValidationEvent
+        .builder()
+        .id("SimpleRestJsonTimestamp")
+        .shape(member)
+        .severity(Severity.WARNING)
+        .message(
+          "test#time: Timestamp shape test#time does not have a timestamp format trait "
+        )
+        .build()
+    )
+    expected.foreach(println)
+    assertEquals(expected.size, result.size)
+  }
+
+}


### PR DESCRIPTION
ensures all members reachable from a service annotated with SimpleRestJson must have a timestamp format too