### PR TITLE
timestamp validator

### DIFF
--- a/modules/core/src/alloy/validation/SimpleRestJsonTimestampValidator.java
+++ b/modules/core/src/alloy/validation/SimpleRestJsonTimestampValidator.java
@@ -73,7 +73,7 @@ public final class SimpleRestJsonTimestampValidator extends AbstractValidator {
 	}
 
 	private ValidationEvent warn(Shape shape) {
-		return warning(shape, "A Timestamp shape  does not have a timestamp format trait");
+		return warning(shape, "A Timestamp shape does not have a timestamp format trait");
 	}
 
 }

--- a/modules/core/src/alloy/validation/SimpleRestJsonTimestampValidator.java
+++ b/modules/core/src/alloy/validation/SimpleRestJsonTimestampValidator.java
@@ -1,0 +1,47 @@
+
+
+package alloy.validation;
+
+        import alloy.SimpleRestJsonTrait;
+        import software.amazon.smithy.model.Model;
+        import software.amazon.smithy.model.neighbor.Walker;
+        import software.amazon.smithy.model.neighbor.NeighborProvider;
+        import software.amazon.smithy.model.validation.AbstractValidator;
+        import software.amazon.smithy.model.shapes.*;
+        import software.amazon.smithy.model.traits.TimestampFormatTrait;
+        import software.amazon.smithy.model.validation.ValidationEvent;
+
+        import java.util.Optional;
+        import java.util.Set;
+        import java.util.List;
+        import java.util.stream.Collectors;
+        import java.util.stream.Stream;
+
+
+public final class SimpleRestJsonTimestampValidator extends AbstractValidator {
+
+    @Override
+    public List<ValidationEvent> validate(Model model) {
+        Walker walker = new Walker(NeighborProvider.of(model));
+        Set<Shape> entryPoints = model.getShapesWithTrait(SimpleRestJsonTrait.class);
+        Stream<Shape> closure = entryPoints.stream()
+                .flatMap(restJsonService -> walker.walkShapes(restJsonService).stream());
+
+        return closure.filter(Shape::isTimestampShape)
+                .flatMap(this::validateTimestamp).collect(Collectors.toList());
+    }
+
+    private Stream<ValidationEvent> validateTimestamp(Shape shape) {
+        if (shape.isTimestampShape() && !shape.getTrait(TimestampFormatTrait.class).isPresent()) {
+            return Stream.of(warn(shape));
+        } else {
+            return Stream.empty();
+        }
+    }
+
+    private ValidationEvent warn(Shape shape) {
+        return warning(shape, "Timestamp shape " + shape.getId() + " does not have a timestamp format trait");
+    }
+
+
+}

--- a/modules/core/src/alloy/validation/SimpleRestJsonTimestampValidator.java
+++ b/modules/core/src/alloy/validation/SimpleRestJsonTimestampValidator.java
@@ -73,7 +73,7 @@ public final class SimpleRestJsonTimestampValidator extends AbstractValidator {
 	}
 
 	private ValidationEvent warn(Shape shape) {
-		return warning(shape, "Timestamp shape " + shape.getId() + " does not have a timestamp format trait");
+		return warning(shape, "A Timestamp shape  does not have a timestamp format trait");
 	}
 
 }

--- a/modules/core/src/alloy/validation/SimpleRestJsonTimestampValidator.java
+++ b/modules/core/src/alloy/validation/SimpleRestJsonTimestampValidator.java
@@ -27,12 +27,13 @@ public final class SimpleRestJsonTimestampValidator extends AbstractValidator {
         Stream<Shape> closure = entryPoints.stream()
                 .flatMap(restJsonService -> walker.walkShapes(restJsonService).stream());
 
-        return closure.filter(Shape::isTimestampShape)
+        return closure.filter(shape -> shape.isTimestampShape() || shape.asMemberShape().isPresent() && model.getShape(shape.asMemberShape().get()
+                .getTarget()).map(Shape::isTimestampShape).orElse(false))
                 .flatMap(this::validateTimestamp).collect(Collectors.toList());
     }
 
     private Stream<ValidationEvent> validateTimestamp(Shape shape) {
-        if (shape.isTimestampShape() && !shape.getTrait(TimestampFormatTrait.class).isPresent()) {
+        if (!shape.getTrait(TimestampFormatTrait.class).isPresent()) {
             return Stream.of(warn(shape));
         } else {
             return Stream.empty();

--- a/modules/core/test/src/alloy/validation/SimpleRestJsonTimestampFormatValidatorSpec.scala
+++ b/modules/core/test/src/alloy/validation/SimpleRestJsonTimestampFormatValidatorSpec.scala
@@ -1,0 +1,77 @@
+
+
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.validation
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes._
+import software.amazon.smithy.model.validation.Severity
+import software.amazon.smithy.model.validation.ValidationEvent
+
+import scala.jdk.CollectionConverters._
+import alloy.SimpleRestJsonTrait
+
+final class SimpleRestJsonTimestampFormatValidatorSpec extends munit.FunSuite {
+
+    test("warn when timestamp shape does not have a timestamp format trait and is reachable from a service with a rest json trait") {
+        val validator = new SimpleRestJsonTimestampValidator()
+        val timestamp = TimestampShape
+                .builder()
+                .id("test#time")
+                .build()
+        val member0 = MemberShape
+                .builder()
+                .id("test#struct$ts")
+                .target(timestamp.getId)
+                .build()
+        val member1 = MemberShape
+                .builder()
+                .id("test#struct$ts2")
+                .target("smithy.api#Timestamp")
+                .build()
+        val struct =
+                StructureShape.builder().id("test#struct").addMember(member0).addMember(member1).build()
+
+        val op = OperationShape.builder().id("test#TestOp").input(struct).build()
+        val service = ServiceShape
+                .builder()
+                .id("test#TestService")
+                .version("1")
+                .addOperation(op)
+                .addTrait(new SimpleRestJsonTrait())
+                .build()
+
+        val model =
+                Model.builder().addShapes(timestamp,member1,struct, op, service).build()
+
+
+        val result = validator.validate(model).asScala.toList
+
+        val expected = List(
+                ValidationEvent
+                        .builder()
+                        .id("SimpleRestJsonTimestamp")
+                        .severity(Severity.WARNING)
+                        .message(
+                                "test#time: Timestamp shape test#time does not have a timestamp format trait "
+                        )
+                        .build()
+        )
+        assertEquals(result.size, 1)
+    }
+
+}

--- a/modules/core/test/src/alloy/validation/SimpleRestJsonTimestampFormatValidatorSpec.scala
+++ b/modules/core/test/src/alloy/validation/SimpleRestJsonTimestampFormatValidatorSpec.scala
@@ -27,7 +27,7 @@ import alloy.SimpleRestJsonTrait
 
 final class SimpleRestJsonTimestampFormatValidatorSpec extends munit.FunSuite {
 
-    test("warn when timestamp shape does not have a timestamp format trait and is reachable from a service with a rest json trait") {
+    test("warn when timestamp shape or member targeting timestamp does not have a timestamp format trait and is reachable from a service with a rest json trait") {
         val validator = new SimpleRestJsonTimestampValidator()
         val timestamp = TimestampShape
                 .builder()
@@ -61,16 +61,6 @@ final class SimpleRestJsonTimestampFormatValidatorSpec extends munit.FunSuite {
 
         val result = validator.validate(model).asScala.toList
 
-        val expected = List(
-                ValidationEvent
-                        .builder()
-                        .id("SimpleRestJsonTimestamp")
-                        .severity(Severity.WARNING)
-                        .message(
-                                "test#time: Timestamp shape test#time does not have a timestamp format trait "
-                        )
-                        .build()
-        )
         assertEquals(result.size, 2)
     }
 

--- a/modules/core/test/src/alloy/validation/SimpleRestJsonTimestampFormatValidatorSpec.scala
+++ b/modules/core/test/src/alloy/validation/SimpleRestJsonTimestampFormatValidatorSpec.scala
@@ -85,7 +85,7 @@ final class SimpleRestJsonTimestampFormatValidatorSpec extends munit.FunSuite {
         .shape(member0)
         .severity(Severity.WARNING)
         .message(
-          "A Timestamp shape  does not have a timestamp format trait"
+          "A Timestamp shape does not have a timestamp format trait"
         )
         .build(),
 

--- a/modules/core/test/src/alloy/validation/SimpleRestJsonTimestampFormatValidatorSpec.scala
+++ b/modules/core/test/src/alloy/validation/SimpleRestJsonTimestampFormatValidatorSpec.scala
@@ -74,12 +74,24 @@ final class SimpleRestJsonTimestampFormatValidatorSpec extends munit.FunSuite {
         .builder()
         .id("SimpleRestJsonTimestamp")
         .severity(Severity.WARNING)
+        .shape(member1)
         .message(
-          "test#time: Timestamp shape test#time does not have a timestamp format trait "
+          "A Timestamp shape  does not have a timestamp format trait"
         )
-        .build()
+        .build(),
+      ValidationEvent
+        .builder()
+        .id("SimpleRestJsonTimestamp")
+        .shape(member0)
+        .severity(Severity.WARNING)
+        .message(
+          "A Timestamp shape  does not have a timestamp format trait"
+        )
+        .build(),
+
     )
     assertEquals(result.size, 2)
+    assertEquals(result, expected)
   }
 
   test("when a timestamp shape  is not accesible from a service annotated with SimpleRestJson a warning is not issued") {
@@ -120,6 +132,7 @@ final class SimpleRestJsonTimestampFormatValidatorSpec extends munit.FunSuite {
     val result = validator.validate(model).asScala.toList
 
     assertEquals(result.size, 0)
+    assertEquals(result, List.empty)
   }
 
   test("when a timestamp shape is annotated with the timestamp format trait a warning is not issued ") {
@@ -153,8 +166,8 @@ final class SimpleRestJsonTimestampFormatValidatorSpec extends munit.FunSuite {
       modelAssembler(timestamp, member0, struct, op, service)
 
     val result = validator.validate(model).asScala.toList
-    println(result)
     assertEquals(result.size, 0)
+    assertEquals(result, List.empty)
   }
   test("when a member shape that is targeting a timestamp is annotated with the timestamp format trait, a warning is not issued ") {
     val timestamp = TimestampShape
@@ -196,5 +209,6 @@ final class SimpleRestJsonTimestampFormatValidatorSpec extends munit.FunSuite {
     val result = validator.validate(model).asScala.toList
 
     assertEquals(result.size, 0)
+    assertEquals(result, List.empty)
   }
 }

--- a/modules/core/test/src/alloy/validation/SimpleRestJsonTimestampFormatValidatorSpec.scala
+++ b/modules/core/test/src/alloy/validation/SimpleRestJsonTimestampFormatValidatorSpec.scala
@@ -90,7 +90,6 @@ final class SimpleRestJsonTimestampFormatValidatorSpec extends munit.FunSuite {
         .build(),
 
     )
-    assertEquals(result.size, 2)
     assertEquals(result, expected)
   }
 
@@ -131,7 +130,6 @@ final class SimpleRestJsonTimestampFormatValidatorSpec extends munit.FunSuite {
 
     val result = validator.validate(model).asScala.toList
 
-    assertEquals(result.size, 0)
     assertEquals(result, List.empty)
   }
 
@@ -166,7 +164,6 @@ final class SimpleRestJsonTimestampFormatValidatorSpec extends munit.FunSuite {
       modelAssembler(timestamp, member0, struct, op, service)
 
     val result = validator.validate(model).asScala.toList
-    assertEquals(result.size, 0)
     assertEquals(result, List.empty)
   }
   test("when a member shape that is targeting a timestamp is annotated with the timestamp format trait, a warning is not issued ") {
@@ -207,8 +204,6 @@ final class SimpleRestJsonTimestampFormatValidatorSpec extends munit.FunSuite {
       modelAssembler(timestamp, member1, member0, struct, op, service)
 
     val result = validator.validate(model).asScala.toList
-
-    assertEquals(result.size, 0)
     assertEquals(result, List.empty)
   }
 }

--- a/modules/core/test/src/alloy/validation/SimpleRestJsonTimestampFormatValidatorSpec.scala
+++ b/modules/core/test/src/alloy/validation/SimpleRestJsonTimestampFormatValidatorSpec.scala
@@ -71,7 +71,7 @@ final class SimpleRestJsonTimestampFormatValidatorSpec extends munit.FunSuite {
                         )
                         .build()
         )
-        assertEquals(result.size, 1)
+        assertEquals(result.size, 2)
     }
 
 }


### PR DESCRIPTION
ensures all members reachable from a service annotated with SimpleRestJson must have a timestamp format too