### PR TITLE
Srj doc fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,20 +66,7 @@ Errors referenced by any operation that's itself referenced by a `@simpleRestJso
 
 ##### Content-types
 
-The `alloy#simpleRestJson` protocol uses a default Content-Type of `application/json`.
-
-Input or output shapes that apply the `@httpPayload` trait on one of their top-level members MUST use a Content-Type that is appropriate for the payload. The following table defines the expected Content-Type header for requests and responses based on the shape targeted by the member marked with the `@httpPayload` trait:
-
-
-| Targeted shape      | Content-Type                                     |
-| ------------------- | ------------------------------------------------ |
-| Has mediaType trait | Use the value of the mediaType trait if present. |
-| string              | text/plain                                       |
-| blob                | application/octet-stream                         |
-| document            | application/json                                 |
-| structure           | application/json                                 |
-| union               | application/json                                 |
-| list/set/map        | application/json                                 |
+The `alloy#simpleRestJson` protocol uses a Content-Type of `application/json`.
 
 ##### JSON Shape Serialization
 

--- a/modules/core/resources/META-INF/smithy/restjson.smithy
+++ b/modules/core/resources/META-INF/smithy/restjson.smithy
@@ -2,12 +2,10 @@ $version: "2"
 
 namespace alloy
 
-/// A rest protocol that primarily deals with JSON
+/// A rest protocol that deals with JSON payloads only
 /// in HTTP requests and responses. These are encoded with
-/// the content type `application/json`. The exception is
-/// for requests/responses of type Blob or String. These are
-/// encoded as `application/octet-stream` and `text/plain`
-/// respectively. See Alloy documentation for more information.
+/// the content type `application/json`.
+///  See Alloy documentation for more information.
 @protocolDefinition(traits: [
     smithy.api#error,
     smithy.api#required,


### PR DESCRIPTION
This PR is to correct documentation both from readme and smithy doc for the simpleRestJson protocol thats says alloy supports binary and string serialization which it does not .
I am not sure if I captured every location 