### PR TITLE
alloy-openapi is a Scala module

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,18 @@ A collection of commonly used Smithy shapes.
 
 Alloy Smithy shapes and validators are published to Maven Central under the following artifact names:
 
+For sbt:
+
+```scala
+"com.disneystreaming.alloy" % "alloy-core" % "x.x.x"
+"com.disneystreaming.alloy" %% "alloy-openapi" % "x.x.x"
 ```
-"com.disneystreaming.alloy:alloy-core:x.x.x"
-"com.disneystreaming.alloy:alloy-openapi:x.x.x"
+
+For mill:
+
+```scala
+ivy"com.disneystreaming.alloy:alloy-core:x.x.x"
+ivy"com.disneystreaming.alloy::alloy-openapi:x.x.x"
 ```
 
 ## Why Alloy?


### PR DESCRIPTION
You need to use `%%` or `::` to pull a version matching the scala version you're using.

Related to https://github.com/disneystreaming/alloy/issues/33