### PR TITLE
Move trait provider spec in the right place

### DIFF
--- a/modules/core/test/resources/META-INF/smithy/manifest
+++ b/modules/core/test/resources/META-INF/smithy/manifest
@@ -1,0 +1,1 @@
+traits.smithy

--- a/modules/core/test/resources/META-INF/smithy/traits.smithy
+++ b/modules/core/test/resources/META-INF/smithy/traits.smithy
@@ -21,6 +21,7 @@ use alloy#nullable
 use alloy#uncheckedExamples
 use alloy#untagged
 use alloy#uuidFormat
+use alloy#simpleRestJson
 
 @dateFormat
 string MyDate
@@ -70,9 +71,11 @@ service MyGrpcService {
 }
 
 @uncheckedExamples([{title: "dummy", input: { name: "john" }}])
+@http(method: "GET", uri: "/age")
 operation GetAge {
     input := {
         @required
+        @httpHeader("X-NAME")
         name: String
     }
     output := {
@@ -92,4 +95,10 @@ structure ProtoStruct {
 union UntaggedUnion {
     a: Integer,
     b: String
+}
+
+@simpleRestJson
+service RestJsonService {
+    version: "1"
+    operations: [GetAge]
 }

--- a/modules/core/test/src/TraitProviderSpec.scala
+++ b/modules/core/test/src/TraitProviderSpec.scala
@@ -1,0 +1,61 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy
+
+import munit.Location
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.traits.Trait
+import software.amazon.smithy.model.validation.ValidatedResult
+
+import scala.io.Source
+
+final class SanitySpec extends munit.FunSuite {
+
+  private val model: ValidatedResult[Model] =
+    Model.assembler().discoverModels().assemble()
+
+  test("traits provider are defined and work") {
+    val unwrapped = model.unwrap()
+    def traitLookup[T <: Trait](c: Class[T])(implicit loc: Location): Unit = {
+      val shapeSet = unwrapped.getShapesWithTrait(c)
+      assert(
+        !shapeSet.isEmpty(),
+        s"Found ${shapeSet.size()} shapes with ${c.getSimpleName()} trait."
+      )
+    }
+
+    val lines = scala.util
+      .Using(
+        Source.fromResource(
+          "META-INF/services/software.amazon.smithy.model.traits.TraitService"
+        )
+      ) {
+        _.getLines().toList
+      }
+      .fold(
+        ex => fail("Failed to load TraitService resource", ex),
+        identity
+      )
+    val classesFQN = lines.map(_.split("\\$").head)
+    val classes =
+      classesFQN.map(name => this.getClass().getClassLoader().loadClass(name))
+    assert(
+      classes.size > 10,
+      s"Loading Trait classes probably failed, only found ${classes.size} classes."
+    )
+    classes.map(c => traitLookup(c.asInstanceOf[Class[Trait]]))
+  }
+}

--- a/modules/protocol-tests/resources/META-INF/smithy/manifest
+++ b/modules/protocol-tests/resources/META-INF/smithy/manifest
@@ -8,4 +8,3 @@ Health.smithy
 Pizza.smithy
 RoundTrip.smithy
 Version.smithy
-traits.smithy

--- a/modules/protocol-tests/sanity/src/SanitySpec.scala
+++ b/modules/protocol-tests/sanity/src/SanitySpec.scala
@@ -16,14 +16,11 @@
 import java.nio.file.Files
 import java.nio.file.Paths
 
-import munit.Location
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ShapeId
-import software.amazon.smithy.model.traits.Trait
 import software.amazon.smithy.model.validation.Severity
 import software.amazon.smithy.model.validation.ValidatedResult
 
-import scala.io.Source
 import scala.jdk.CollectionConverters._
 import scala.jdk.StreamConverters._
 
@@ -75,37 +72,5 @@ final class SanitySpec extends munit.FunSuite {
         })
         .orElseGet(() => false)
     )
-  }
-
-  test("traits provider are defined and work") {
-    val unwrapped = model.unwrap()
-    def traitLookup[T <: Trait](c: Class[T])(implicit loc: Location): Unit = {
-      val shapeSet = unwrapped.getShapesWithTrait(c)
-      assert(
-        !shapeSet.isEmpty(),
-        s"Found ${shapeSet.size()} shapes with ${c.getSimpleName()} trait."
-      )
-    }
-
-    val lines = scala.util
-      .Using(
-        Source.fromResource(
-          "META-INF/services/software.amazon.smithy.model.traits.TraitService"
-        )
-      ) {
-        _.getLines().toList
-      }
-      .fold(
-        ex => fail("Failed to load TraitService resource", ex),
-        identity
-      )
-    val classesFQN = lines.map(_.split("\\$").head)
-    val classes =
-      classesFQN.map(name => this.getClass().getClassLoader().loadClass(name))
-    assert(
-      classes.size > 10,
-      s"Loading Trait classes probably failed, only found ${classes.size} classes."
-    )
-    classes.map(c => traitLookup(c.asInstanceOf[Class[Trait]]))
   }
 }


### PR DESCRIPTION
Complete mishap on my side. Definitely belong in the `core/test` module. 