### PR TITLE
Introduce protoInlinedOneOf annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A collection of commonly used Smithy shapes.
     - [Full List of Supported Traits](#full-list-of-supported-traits)
   - [alloy.proto#grpc](#alloyprotogrpc)
     - [alloy.proto#protoIndex](#alloyprotoprotoindex)
+    - [alloy.proto#protoInlinedOneOf](#alloyprotoprotoinlinedoneof)
     - [alloy.proto#protoNumType](#alloyprotoprotonumtype)
     - [alloy.proto#protoEnabled](#alloyprotoprotoenabled)
     - [alloy.proto#protoReservedFields](#alloyprotoprotoreservedfields)
@@ -349,6 +350,51 @@ message Test {
 ```
 
 When one field is annotated with a `@protoIndex`, all fields have to be annotated with it. This includes the fields of any structure used within the structure.
+
+#### alloy.proto#protoInlinedOneOf
+
+This annotation can be used to customize the rendering on Unions in protobuf. When you add this annotation to a Union, you must make sure that this Union is used exactly once as part of a structure. A validator bundled in this library will ensure this is the case.
+
+For example, this is valid:
+
+```smithy
+structure Test {
+  myUnion: MyUnion
+}
+
+@protoInlinedOneOf
+union MyUnion {
+  a: String,
+  b: Integer
+}
+```
+
+But this is not because the `MyUnion` is used in multiple shapes.
+
+```smithy
+structure Test {
+  myUnion: MyUnion
+}
+structure OtherStruct {
+  aUnion: MyUnion
+}
+
+@protoInlinedOneOf
+union MyUnion {
+  a: String,
+  b: Integer
+}
+```
+
+This is also invalid because `MyUnion` is never used.
+
+```smithy
+@protoInlinedOneOf
+union MyUnion {
+  a: String,
+  b: Integer
+}
+```
 
 #### alloy.proto#protoNumType
 

--- a/modules/core/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/modules/core/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -11,6 +11,7 @@ alloy.openapi.OpenApiExtensionsTrait$Provider
 alloy.proto.GrpcTrait$Provider
 alloy.proto.ProtoEnabledTrait$Provider
 alloy.proto.ProtoIndexTrait$Provider
+alloy.proto.ProtoInlinedOneOfTrait$Provider
 alloy.proto.ProtoNumTypeTrait$Provider
 alloy.proto.ProtoReservedFieldsTrait$Provider
 alloy.SimpleRestJsonTrait$Provider

--- a/modules/core/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/modules/core/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -1,5 +1,6 @@
 alloy.proto.validation.GrpcTraitValidator
 alloy.proto.validation.ProtoIndexTraitValidator
+alloy.proto.validation.ProtoInlinedOneOfValidator
 alloy.proto.validation.ProtoReservedFieldsTraitValidator
 alloy.validation.DefaultValueTraitValidator
 alloy.validation.DiscriminatedUnionValidator

--- a/modules/core/resources/META-INF/smithy/proto/proto.smithy
+++ b/modules/core/resources/META-INF/smithy/proto/proto.smithy
@@ -74,3 +74,22 @@ structure Range {
 /// GRPC service.
 @trait(selector: ":test(structure, service)")
 structure protoEnabled {}
+
+
+/// This trait can be used to customize the rendering of an
+/// Union shape during the conversion to Protobuf models.
+/// Union in Protobuf are typically encoded using `oneOf`.
+///
+/// `oneOf` can only be used within `message` and each of their
+/// member has an index. This makes them tricky to render.
+/// One possible solution is to create a synthetic `message` to
+/// host the `oneOf`, and then use that `message` FQN at use site
+/// when refering to the Union.
+/// There is an alternate encoding where you render the `oneOf`
+/// inside the `message` where it's used. You can only use this encoding
+/// if the Union is used only inside of one `structure`.
+///
+/// You can use this trait, along with the validator provided, to
+/// implement this encoding.
+@trait(selector: "union")
+structure protoInlinedOneOf {}

--- a/modules/core/src/alloy/proto/ProtoInlinedOneOfTrait.java
+++ b/modules/core/src/alloy/proto/ProtoInlinedOneOfTrait.java
@@ -1,0 +1,46 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.proto;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AnnotationTrait;
+import software.amazon.smithy.model.traits.AbstractTrait;
+
+public class ProtoInlinedOneOfTrait extends AnnotationTrait {
+
+	public static ShapeId ID = ShapeId.from("alloy.proto#protoInlinedOneOf");
+
+	public ProtoInlinedOneOfTrait(ObjectNode node) {
+		super(ID, node);
+	}
+
+	public ProtoInlinedOneOfTrait() {
+		super(ID, Node.objectNode());
+	}
+
+	public static final class Provider extends AbstractTrait.Provider {
+		public Provider() {
+			super(ID);
+		}
+
+		@Override
+		public ProtoInlinedOneOfTrait createTrait(ShapeId target, Node node) {
+			return new ProtoInlinedOneOfTrait(node.expectObjectNode());
+		}
+	}
+}

--- a/modules/core/src/alloy/proto/validation/ProtoInlinedOneOfValidator.java
+++ b/modules/core/src/alloy/proto/validation/ProtoInlinedOneOfValidator.java
@@ -1,0 +1,56 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.proto.validation;
+
+import alloy.proto.ProtoInlinedOneOfTrait;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.Severity;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class ProtoInlinedOneOfValidator extends AbstractValidator {
+	public final static String USAGE_COUNT_EXCEEDED = "UsageCountExceeded";
+	public final static String UNUSED_UNION = "UnusedUnion";
+
+	@Override
+	public List<ValidationEvent> validate(Model model) {
+		return model.getUnionShapes().stream().filter(shape -> shape.hasTrait(ProtoInlinedOneOfTrait.class))
+				.flatMap(unionShape -> {
+					final long usageCount = model.getMemberShapes().stream()
+							.filter(s -> s.getTarget() == unionShape.getId()).count();
+					if (usageCount > 1) {
+						return Stream.of(ValidationEvent.builder().id(USAGE_COUNT_EXCEEDED).message(
+								"Unions annotated with @protoInlinedOneOf can only be used inside of one structure shape.")
+								.shape(unionShape).severity(Severity.ERROR).build());
+					} else if (usageCount == 0) {
+						return Stream.of(ValidationEvent.builder().id(UNUSED_UNION)
+								.message(
+										"Unions annotated with @protoInlinedOneOf must be used in one structure shape.")
+								.shape(unionShape).severity(Severity.ERROR).build());
+					} else {
+						return Stream.empty();
+					}
+				}).collect(Collectors.toList());
+	}
+
+}

--- a/modules/core/test/resources/META-INF/smithy/traits.smithy
+++ b/modules/core/test/resources/META-INF/smithy/traits.smithy
@@ -12,6 +12,7 @@ use alloy.openapi#openapiExtensions
 use alloy.proto#grpc
 use alloy.proto#protoEnabled
 use alloy.proto#protoIndex
+use alloy.proto#protoInlinedOneOf
 use alloy.proto#protoNumType
 use alloy.proto#protoReservedFields
 use alloy#dateFormat
@@ -101,4 +102,15 @@ union UntaggedUnion {
 service RestJsonService {
     version: "1"
     operations: [GetAge]
+}
+
+@protoEnabled
+structure UnionHost {
+    value: OtherUnion
+}
+
+@protoInlinedOneOf
+union OtherUnion {
+    a: String,
+    b: Integer
 }

--- a/modules/core/test/src/alloy/proto/validation/ProtoInlinedOneOfValidatorSuite.scala
+++ b/modules/core/test/src/alloy/proto/validation/ProtoInlinedOneOfValidatorSuite.scala
@@ -1,0 +1,93 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.proto.validation
+
+import alloy.proto.ProtoInlinedOneOfTrait;
+import munit.FunSuite
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes._
+
+import scala.jdk.CollectionConverters._
+
+class ProtoInlinedOneOfValidatorSuite extends FunSuite {
+
+  val req = StructureShape.builder.id("com.example#Request").build
+  val res = StructureShape.builder.id("com.example#Response").build
+  val error = StructureShape.builder.id("com.example#Error").build
+
+  test("union annotated is used exactly once") {
+    val union = UnionShape.builder
+      .id("com.example#MyUnion")
+      .addTrait(new ProtoInlinedOneOfTrait())
+      .build
+    val structure = StructureShape.builder
+      .id("com.example#MyStructure")
+      .addMember("myUnion", union.getId())
+      .build
+
+    val model = Model.builder.addShapes(structure, union).build
+    val events = new ProtoInlinedOneOfValidator()
+      .validate(model)
+      .asScala
+      .toList
+    assertEquals(events.length, 0)
+  }
+
+  test("union annotated must be used") {
+    val union = UnionShape.builder
+      .id("com.example#MyUnion")
+      .addTrait(new ProtoInlinedOneOfTrait())
+      .build
+
+    val model = Model.builder.addShapes(union).build
+    val events = new ProtoInlinedOneOfValidator()
+      .validate(model)
+      .asScala
+      .toList
+    assertEquals(events.length, 1)
+    assertEquals(
+      events(0).getEventId(),
+      ProtoInlinedOneOfValidator.UNUSED_UNION
+    )
+  }
+
+  test("union annotated is used more than once") {
+    val union = UnionShape.builder
+      .id("com.example#MyUnion")
+      .addTrait(new ProtoInlinedOneOfTrait())
+      .build
+    val structure = StructureShape.builder
+      .id("com.example#MyStructure")
+      .addMember("myUnion", union.getId())
+      .build
+    val structure2 = StructureShape.builder
+      .id("com.example#OtherStructure")
+      .addMember("myUnion", union.getId())
+      .build
+
+    val model = Model.builder.addShapes(structure, structure2, union).build
+    val events = new ProtoInlinedOneOfValidator()
+      .validate(model)
+      .asScala
+      .toList
+    assertEquals(events.length, 1)
+    assertEquals(
+      events(0).getEventId(),
+      ProtoInlinedOneOfValidator.USAGE_COUNT_EXCEEDED
+    )
+  }
+
+}


### PR DESCRIPTION
Protobuf oneOf are tricky to render. We introduce this annotation to allow the customization of Union rendering. See the docs for more information.

This annotation is going to be used in the context of https://github.com/disneystreaming/smithy-translate