### PR TITLE
add data examples trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A collection of commonly used Smithy shapes.
   - [alloy#dateFormat](#alloydateformat)
   - [alloy#nullable](#alloynullable)
   - [alloy#defaultValue](#alloydefaultvalue)
+  - [alloy#dataExamples](#alloydataexamples)
   - [alloy.openapi](#alloyopenapi)
     - [alloy.openapi#openapiExtensions](#alloyopenapiopenapiextensions)
 - [Protocol Compliance Module](#protocol-compliance-module)
@@ -453,6 +454,27 @@ structure Foo {
  @required
  @nullable
  bar: String
+}
+```
+
+### alloy#dataExamples
+
+This trait allows you to provide concrete examples of what instances of a given shape will look like. The examples provided must match the structure of the shape they are provided for. A validator will check that such is the case.
+
+```smithy
+@dataExamples([
+  {
+    name: "Emily",
+    age: 64
+  },
+  {
+    name: "Allison",
+    age: 22
+  }
+])
+structure User {
+    name: String
+    age: Integer
 }
 ```
 

--- a/modules/core/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/modules/core/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -3,8 +3,8 @@ alloy.common.EmailFormatTrait$Provider
 alloy.common.HexColorCodeFormatTrait$Provider
 alloy.common.LanguageCodeFormatTrait$Provider
 alloy.common.LanguageTagFormatTrait$Provider
-alloy.DateFormatTrait$Provider
 alloy.DataExamplesTrait$Provider
+alloy.DateFormatTrait$Provider
 alloy.DefaultValueTrait$Provider
 alloy.DiscriminatedUnionTrait$Provider
 alloy.NullableTrait$Provider

--- a/modules/core/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/modules/core/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -4,6 +4,7 @@ alloy.common.HexColorCodeFormatTrait$Provider
 alloy.common.LanguageCodeFormatTrait$Provider
 alloy.common.LanguageTagFormatTrait$Provider
 alloy.DateFormatTrait$Provider
+alloy.DataExamplesTrait$Provider
 alloy.DefaultValueTrait$Provider
 alloy.DiscriminatedUnionTrait$Provider
 alloy.NullableTrait$Provider

--- a/modules/core/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/modules/core/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -2,6 +2,7 @@ alloy.proto.validation.GrpcTraitValidator
 alloy.proto.validation.ProtoIndexTraitValidator
 alloy.proto.validation.ProtoInlinedOneOfValidator
 alloy.proto.validation.ProtoReservedFieldsTraitValidator
+alloy.validation.DataExamplesTraitValidator
 alloy.validation.DefaultValueTraitValidator
 alloy.validation.DiscriminatedUnionValidator
 alloy.validation.SimpleRestJsonHttpHeaderValidator

--- a/modules/core/resources/META-INF/smithy/examples.smithy
+++ b/modules/core/resources/META-INF/smithy/examples.smithy
@@ -1,0 +1,8 @@
+$version: "2"
+
+namespace alloy
+
+@trait(selector: ":not(:test(service, operation, resource))")
+list dataExamples {
+  member: Document
+}

--- a/modules/core/resources/META-INF/smithy/manifest
+++ b/modules/core/resources/META-INF/smithy/manifest
@@ -1,5 +1,6 @@
-documentation.smithy
 common/common.smithy
+documentation.smithy
+examples.smithy
 formats.smithy
 openapi/openapi.smithy
 presence.smithy

--- a/modules/core/src/alloy/DataExamplesTrait.java
+++ b/modules/core/src/alloy/DataExamplesTrait.java
@@ -1,0 +1,97 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy;
+
+import software.amazon.smithy.model.node.ArrayNode;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AbstractTrait;
+import software.amazon.smithy.model.traits.AbstractTraitBuilder;
+import software.amazon.smithy.model.traits.TraitService;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public final class DataExamplesTrait extends AbstractTrait implements ToSmithyBuilder<DataExamplesTrait> {
+	public static final ShapeId ID = ShapeId.from("alloy#dataExamples");
+
+	private final List<Node> examples;
+
+	private DataExamplesTrait(Builder builder) {
+		super(ID, builder.getSourceLocation());
+		this.examples = new ArrayList<>(builder.examples);
+	}
+
+	public List<Node> getExamples() {
+		return examples;
+	}
+
+	@Override
+	protected Node createNode() {
+		return examples.stream().collect(ArrayNode.collect(getSourceLocation()));
+	}
+
+	@Override
+	public Builder toBuilder() {
+		Builder builder = new Builder().sourceLocation(getSourceLocation());
+		examples.forEach(builder::addExample);
+		return builder;
+	}
+
+	/**
+	 * @return Returns a builder used to create an examples trait.
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static final class Builder extends AbstractTraitBuilder<DataExamplesTrait, Builder> {
+		private final List<Node> examples = new ArrayList<>();
+
+		public Builder addExample(Node example) {
+			examples.add(Objects.requireNonNull(example));
+			return this;
+		}
+
+		public Builder clearExamples() {
+			examples.clear();
+			return this;
+		}
+
+		@Override
+		public DataExamplesTrait build() {
+			return new DataExamplesTrait(this);
+		}
+	}
+
+	public static final class Provider implements TraitService {
+		@Override
+        public ShapeId getShapeId() {
+			return ID;
+		}
+
+	public DataExamplesTrait createTrait(ShapeId target, Node value) {
+			Builder builder = builder().sourceLocation(value);
+			value.expectArrayNode().forEach(builder::addExample);
+			DataExamplesTrait result = builder.build();
+			result.setNodeCache(value);
+			return result;
+		}
+	}
+
+}

--- a/modules/core/src/alloy/validation/DataExamplesTraitValidator.java
+++ b/modules/core/src/alloy/validation/DataExamplesTraitValidator.java
@@ -1,0 +1,48 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.validation;
+
+import alloy.DataExamplesTrait;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.NodeValidationVisitor;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class DataExamplesTraitValidator extends AbstractValidator {
+	@Override
+	public List<ValidationEvent> validate(Model model) {
+		List<ValidationEvent> events = new ArrayList<>();
+		for (Shape shape : model.getShapesWithTrait(DataExamplesTrait.class)) {
+			DataExamplesTrait trt = shape.getTrait(DataExamplesTrait.class).get();
+			for (Node example : trt.getExamples()) {
+				NodeValidationVisitor visitor = createVisitor(example, model, shape);
+				events.addAll(shape.accept(visitor));
+			}
+		}
+
+		return events;
+	}
+
+	private NodeValidationVisitor createVisitor(Node value, Model model, Shape shape) {
+		return NodeValidationVisitor.builder().model(model).eventShapeId(shape.getId()).value(value)
+				.startingContext("DataExample of `" + shape.toShapeId().toString() + "`").eventId(getName()).build();
+	}
+}

--- a/modules/core/test/resources/META-INF/smithy/traits.smithy
+++ b/modules/core/test/resources/META-INF/smithy/traits.smithy
@@ -1,4 +1,3 @@
-
 $version: "2"
 
 namespace alloy.test
@@ -23,6 +22,7 @@ use alloy#uncheckedExamples
 use alloy#untagged
 use alloy#uuidFormat
 use alloy#simpleRestJson
+use alloy#dataExamples
 
 @dateFormat
 string MyDate
@@ -114,3 +114,6 @@ union OtherUnion {
     a: String,
     b: Integer
 }
+
+@dataExamples(["one", "two"])
+string TestString

--- a/modules/core/test/resources/META-INF/smithy/traits.smithy
+++ b/modules/core/test/resources/META-INF/smithy/traits.smithy
@@ -115,5 +115,17 @@ union OtherUnion {
     b: Integer
 }
 
-@dataExamples(["one", "two"])
-string TestString
+@dataExamples([
+    {
+        one: "numberOne",
+        two: 2
+    },
+    {
+        one: "numberOneAgain",
+        two: 22
+    }
+])
+structure TestExamples {
+    one: String
+    two: Integer
+}

--- a/modules/core/test/src/alloy/validation/DataExamplesTraitValidatorSpec.scala
+++ b/modules/core/test/src/alloy/validation/DataExamplesTraitValidatorSpec.scala
@@ -1,0 +1,75 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.validation
+
+import software.amazon.smithy.model.shapes.StringShape
+import software.amazon.smithy.model.shapes.ShapeId
+import alloy.DataExamplesTrait
+import software.amazon.smithy.model.node.ObjectNode
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.validation.ValidationEvent
+import scala.jdk.CollectionConverters._
+import software.amazon.smithy.model.validation.Severity
+import software.amazon.smithy.model.node.StringNode
+import software.amazon.smithy.model.SourceLocation
+
+final class DataExamplesTraitValidatorSpec extends munit.FunSuite {
+
+  private val validator = new DataExamplesTraitValidator
+
+  test("find when node does not match shape") {
+    val example = DataExamplesTrait
+      .builder()
+      .addExample(ObjectNode.builder().withMember("something", false).build())
+      .build()
+    val shape = StringShape
+      .builder()
+      .id(ShapeId.fromParts("test", "TestString"))
+      .addTrait(example)
+      .build()
+    val model = Model.builder().addShape(shape).build()
+    val result = validator.validate(model).asScala.toList
+    val expected = List(
+      ValidationEvent
+        .builder()
+        .id("DataExamplesTrait")
+        .shape(shape)
+        .severity(Severity.ERROR)
+        .message(
+          "DataExample of `test#TestString`: Expected string value for string shape, `test#TestString`; found object value"
+        )
+        .build()
+    )
+    assertEquals(result, expected)
+  }
+
+  test("no errors when node matches shape") {
+    val example = DataExamplesTrait
+      .builder()
+      .addExample(new StringNode("something", SourceLocation.NONE))
+      .build()
+    val shape = StringShape
+      .builder()
+      .id(ShapeId.fromParts("test", "TestString"))
+      .addTrait(example)
+      .build()
+    val model = Model.builder().addShape(shape).build()
+    val result = validator.validate(model).asScala.toList
+    val expected = List.empty
+    assertEquals(result, expected)
+  }
+
+}


### PR DESCRIPTION
Adds a trait that can be used to document examples of what instances of shapes will look like. Will be used in OpenAPI conversion (to and from smithy).