### PR TITLE
enhance data examples trait

### DIFF
--- a/modules/core/resources/META-INF/smithy/examples.smithy
+++ b/modules/core/resources/META-INF/smithy/examples.smithy
@@ -2,6 +2,16 @@ $version: "2"
 
 namespace alloy
 
+/// A trait for specifying what example data looks like. Differs from the `smithy.api#examples` trait in that
+/// it can be used for any shape, not just operations. Below is an explanation of the different example formats
+/// that are supported.
+/// 1. SMITHY - this means that the examples will be using the `Document` abstraction and will be specified in
+/// a protocol agnostic way
+/// 2. JSON - this means the examples will use the `Document` abstraction, but will not be validated by the smithy
+/// `NodeValidationVisitor` like the first type are. This type can be used to specify protocol specific examples
+/// 3. STRING - this is just a string example and anything can be provided inside of the string.
+/// This can be helpful for showing e.g. xml or another encoding that isn't JSON and therefore doesn't fit nicely
+///  with `Node` semantics
 @trait(selector: ":not(:test(service, operation, resource))")
 list dataExamples {
   member: DataExample

--- a/modules/core/resources/META-INF/smithy/examples.smithy
+++ b/modules/core/resources/META-INF/smithy/examples.smithy
@@ -4,5 +4,11 @@ namespace alloy
 
 @trait(selector: ":not(:test(service, operation, resource))")
 list dataExamples {
-  member: Document
+  member: DataExample
+}
+
+union DataExample {
+  smithy: Document
+  json: Document
+  string: String
 }

--- a/modules/core/src/alloy/validation/DataExamplesTraitValidator.java
+++ b/modules/core/src/alloy/validation/DataExamplesTraitValidator.java
@@ -32,9 +32,11 @@ public final class DataExamplesTraitValidator extends AbstractValidator {
 		List<ValidationEvent> events = new ArrayList<>();
 		for (Shape shape : model.getShapesWithTrait(DataExamplesTrait.class)) {
 			DataExamplesTrait trt = shape.getTrait(DataExamplesTrait.class).get();
-			for (Node example : trt.getExamples()) {
-				NodeValidationVisitor visitor = createVisitor(example, model, shape);
-				events.addAll(shape.accept(visitor));
+			for (DataExamplesTrait.DataExample example : trt.getExamples()) {
+				if (example.getExampleType() == DataExamplesTrait.DataExampleType.SMITHY) {
+					NodeValidationVisitor visitor = createVisitor(example.getContent(), model, shape);
+					events.addAll(shape.accept(visitor));
+				}
 			}
 		}
 

--- a/modules/core/test/resources/META-INF/smithy/traits.smithy
+++ b/modules/core/test/resources/META-INF/smithy/traits.smithy
@@ -117,15 +117,37 @@ union OtherUnion {
 
 @dataExamples([
     {
-        one: "numberOne",
-        two: 2
+        smithy: {
+            one: "numberOne",
+            two: 2
+        }
     },
     {
-        one: "numberOneAgain",
-        two: 22
+        smithy: {
+            one: "numberOneAgain",
+            two: 22
+        }
     }
 ])
 structure TestExamples {
+    one: String
+    two: Integer
+}
+
+@dataExamples([{
+    json: {
+        test: "numberOne"
+    }
+}])
+structure TestJsonExamples {
+    one: String
+    two: Integer
+}
+
+@dataExamples([{
+    string: "test"
+}])
+structure TestStringExamples {
     one: String
     two: Integer
 }

--- a/modules/openapi/test/resources/foo.json
+++ b/modules/openapi/test/resources/foo.json
@@ -200,6 +200,9 @@
           "breed": {
             "type": "string"
           }
+        },
+        "example": {
+          "name": "Woof"
         }
       },
       "DoubleOrFloat": {
@@ -263,6 +266,9 @@
               "$ref": "#/components/schemas/SomeValue"
             }
           }
+        },
+        "example": {
+          "values": []
         }
       },
       "GreetOutputPayload": {

--- a/modules/openapi/test/resources/foo.smithy
+++ b/modules/openapi/test/resources/foo.smithy
@@ -78,20 +78,28 @@ union DoubleOrFloat {
   double: Double
 }
 
-@dataExamples([
-  {
+@dataExamples([{
+  smithy: {
     name: "Meow"
   }
-])
+}])
 structure Cat {
   name: String
 }
 
+@dataExamples([{
+  json: {
+    name: "Woof"
+  }
+}])
 structure Dog {
   name: String,
   breed: String
 }
 
+@dataExamples([{
+  string: "{\"values\": []}"
+}])
 structure ValuesResponse {
   values: Values
 }


### PR DESCRIPTION
Makes it so there are three types of dataExamples that can be provided:

1. SMITHY - this means that the examples will be using the `Node` abstraction and will be specified in a protocol agnostic way
2. JSON - this means the examples will use the `Node` abstraction, but will not be validated by the smithy `NodeValidationVisitor` like the first type are. This type can be used to specify protocol specific examples
3. STRING - this is just a string example and anything can be provided inside of the string. This can be helpful for showing e.g. xml or another encoding that isn't JSON and therefore doesn't fit nicely with `Node` semantics