### PR TITLE
Add httpResponseCode to documented supported traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ This protocol is aware of the following `smithy.api` traits provided out of the 
 * [operations and services](https://awslabs.github.io/smithy/1.0/spec/core/model.html#service)
 * [enumerations](https://awslabs.github.io/smithy/1.0/spec/core/constraint-traits.html#enum-trait)
 * [error trait](https://awslabs.github.io/smithy/1.0/spec/core/type-refinement-traits.html#error-trait)
-* [http traits](https://awslabs.github.io/smithy/1.0/spec/core/http-traits.html), including **http**, **httpError**, **httpLabel**, **httpHeader**, **httpPayload**, **httpQuery**, **httpPrefixHeaders**, **httpQueryParams**.
+* [http traits](https://awslabs.github.io/smithy/1.0/spec/core/http-traits.html), including **http**, **httpError**, **httpLabel**, **httpHeader**, **httpPayload**, **httpQuery**, **httpPrefixHeaders**, **httpQueryParams**, **httpResponseCode**.
 * [timestampFormat trait](https://awslabs.github.io/smithy/1.0/spec/core/protocol-traits.html?highlight=timestampformat#timestampformat-trait)
 
 Furthermore, it contains several traits for customizing your APIs.
@@ -292,6 +292,7 @@ are encoded as such
 - smithy.api#httpPrefixHeaders
 - smithy.api#httpQuery
 - smithy.api#httpQueryParams
+- smithy.api#httpResponseCode
 - smithy.api#jsonName
 - smithy.api#timestampFormat
 - alloy#uncheckedExamples

--- a/modules/core/resources/META-INF/smithy/restjson.smithy
+++ b/modules/core/resources/META-INF/smithy/restjson.smithy
@@ -7,26 +7,28 @@ namespace alloy
 /// the content type `application/json`.
 /// See Alloy documentation for more information.
 @protocolDefinition(traits: [
-    smithy.api#default,
-    smithy.api#error,
-    smithy.api#http,
-    smithy.api#httpError,
-    smithy.api#httpHeader,
-    smithy.api#httpLabel,
-    smithy.api#httpPayload,
-    smithy.api#httpPrefixHeaders,
-    smithy.api#httpQuery,
-    smithy.api#httpQueryParams,
-    smithy.api#jsonName,
-    smithy.api#length,
-    smithy.api#pattern,
-    smithy.api#range,
-    smithy.api#required,
-    smithy.api#timestampFormat,
-    uncheckedExamples,
-    uuidFormat,
-    discriminated,
-    untagged,
+
+    smithy.api#default
+    smithy.api#error
+    smithy.api#http
+    smithy.api#httpError
+    smithy.api#httpHeader
+    smithy.api#httpLabel
+    smithy.api#httpPayload
+    smithy.api#httpPrefixHeaders
+    smithy.api#httpQuery
+    smithy.api#httpQueryParams
+    smithy.api#httpResponseCode
+    smithy.api#jsonName
+    smithy.api#length
+    smithy.api#pattern
+    smithy.api#range
+    smithy.api#required
+    smithy.api#timestampFormat
+    uncheckedExamples
+    uuidFormat
+    discriminated
+    untagged
 ])
 @trait(selector: "service")
 structure simpleRestJson {}


### PR DESCRIPTION
The trait seems to be supported in `simpleRestJson` so I added it. Please let me know if it needs to be updated anywhere else.