### PR TITLE
add structure pattern trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A collection of commonly used Smithy shapes.
   - [alloy#nullable](#alloynullable)
   - [alloy#defaultValue](#alloydefaultvalue)
   - [alloy#dataExamples](#alloydataexamples)
+  - [alloy#structurePattern](#alloystructurepattern)
   - [alloy.openapi](#alloyopenapi)
     - [alloy.openapi#openapiExtensions](#alloyopenapiopenapiextensions)
 - [Protocol Compliance Module](#protocol-compliance-module)
@@ -490,6 +491,28 @@ structure User {
     age: Integer
 }
 ```
+
+### alloy#structurePattern
+
+The `alloy#structurePattern` trait provides a way to specify that a given `String` will conform to a provided format and that it should be parsed into a `Structure` rather than a `String`. For example:
+
+```smithy
+@structurePattern(pattern: "{foo}_{bar}", target: FooBar)
+string FooBarString
+
+structure FooBar {
+  @required
+  foo: String
+  @required
+  bar: Integer
+}
+```
+
+Now wherever `FooBarString` is used, it will really be parsing the string into the structure `FooBar`. There are a few requirements for using the `structurePattern` trait that are checked by a validator:
+
+- The target structure must have all required members and all members must target simple shapes.
+- The provided pattern must have all parameters separated by at least one character. The reason for this is that if there is no separation (e.g. "{foo}{bar}") then a parser would not be able to tell when one starts and the other begins.
+- There must be a provided pattern parameter for each member of the structure.
 
 ### alloy.openapi
 

--- a/modules/core/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/modules/core/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -16,6 +16,7 @@ alloy.proto.ProtoInlinedOneOfTrait$Provider
 alloy.proto.ProtoNumTypeTrait$Provider
 alloy.proto.ProtoReservedFieldsTrait$Provider
 alloy.SimpleRestJsonTrait$Provider
+alloy.StructurePatternTrait$Provider
 alloy.UncheckedExamplesTrait$Provider
 alloy.UntaggedUnionTrait$Provider
 alloy.UuidFormatTrait$Provider

--- a/modules/core/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/modules/core/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -7,3 +7,4 @@ alloy.validation.DefaultValueTraitValidator
 alloy.validation.DiscriminatedUnionValidator
 alloy.validation.SimpleRestJsonHttpHeaderValidator
 alloy.validation.SimpleRestJsonValidator
+alloy.validation.StructurePatternTraitValidator

--- a/modules/core/resources/META-INF/smithy/manifest
+++ b/modules/core/resources/META-INF/smithy/manifest
@@ -6,5 +6,6 @@ openapi/openapi.smithy
 presence.smithy
 proto/proto.smithy
 restjson.smithy
+string.smithy
 unions.smithy
 uuid.smithy

--- a/modules/core/resources/META-INF/smithy/restjson.smithy
+++ b/modules/core/resources/META-INF/smithy/restjson.smithy
@@ -7,7 +7,6 @@ namespace alloy
 /// the content type `application/json`.
 /// See Alloy documentation for more information.
 @protocolDefinition(traits: [
-
     smithy.api#default
     smithy.api#error
     smithy.api#http

--- a/modules/core/resources/META-INF/smithy/string.smithy
+++ b/modules/core/resources/META-INF/smithy/string.smithy
@@ -1,0 +1,12 @@
+$version: "2"
+
+namespace alloy
+
+@trait(selector: "string")
+structure structurePattern {
+  @required
+  pattern: String,
+  @required
+  @idRef(selector: "structure")
+  target: String
+}

--- a/modules/core/src/alloy/StructurePatternTrait.java
+++ b/modules/core/src/alloy/StructurePatternTrait.java
@@ -1,0 +1,112 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AbstractTrait;
+import software.amazon.smithy.model.traits.AbstractTraitBuilder;
+import software.amazon.smithy.model.traits.TraitService;
+import software.amazon.smithy.utils.ToSmithyBuilder;
+
+public final class StructurePatternTrait extends AbstractTrait implements ToSmithyBuilder<StructurePatternTrait> {
+    public static final ShapeId ID = ShapeId.from("alloy#structurePattern");
+    private final ShapeId target;
+    private final String pattern;
+
+    private StructurePatternTrait(Builder builder) {
+        super(ID, builder.getSourceLocation());
+        this.target = builder.getTarget();
+        this.pattern = builder.getPattern();
+    }
+
+    public ShapeId getTarget() {
+        return this.target;
+    }
+
+    public String getPattern() {
+        return this.pattern;
+    }
+
+    @Override
+    protected Node createNode() {
+        return ObjectNode.builder().withMember("target", target.toString()).withMember("pattern", pattern).build();
+    }
+
+    @Override
+    public Builder toBuilder() {
+        Builder builder = new Builder().sourceLocation(getSourceLocation());
+        builder.setTarget(target);
+        builder.setPattern(pattern);
+        return builder;
+    }
+
+    /**
+     * @return Returns a builder used to create an examples trait.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder extends AbstractTraitBuilder<StructurePatternTrait, Builder> {
+        private ShapeId target;
+        private String pattern;
+
+        public Builder setTarget(ShapeId target) {
+            this.target = target;
+            return this;
+        }
+
+        public Builder setPattern(String pattern) {
+            this.pattern = pattern;
+            return this;
+        }
+
+        public ShapeId getTarget() {
+            return target;
+        }
+
+        public String getPattern() {
+            return pattern;
+        }
+
+        @Override
+        public StructurePatternTrait build() {
+            return new StructurePatternTrait(this);
+        }
+    }
+
+    public static final class Provider implements TraitService {
+        @Override
+        public ShapeId getShapeId() {
+            return ID;
+        }
+
+        public StructurePatternTrait createTrait(ShapeId target, Node value) {
+            Builder builder = builder().sourceLocation(value);
+            ObjectNode on = value.expectObjectNode();
+            String pattern = on.expectStringMember("pattern").getValue();
+            ShapeId tar = on.expectMember("target").expectStringNode().expectShapeId();
+            builder.setPattern(pattern);
+            builder.setTarget(tar);
+            StructurePatternTrait result = builder.build();
+            result.setNodeCache(value);
+            return result;
+        }
+    }
+
+}

--- a/modules/core/src/alloy/validation/StructurePatternTraitValidator.java
+++ b/modules/core/src/alloy/validation/StructurePatternTraitValidator.java
@@ -57,6 +57,10 @@ public final class StructurePatternTraitValidator extends AbstractValidator {
                     events.add(error(patternShape, String.format("Pattern params must not target optional structure members, but '%s' is optional", key)));
                 }
 			});
+
+            if (trt.getPattern().contains("}{")) {
+                events.add(error(patternShape, "Params must be separated by at least one character"));
+            }
 		});
 
 		return events;

--- a/modules/core/src/alloy/validation/StructurePatternTraitValidator.java
+++ b/modules/core/src/alloy/validation/StructurePatternTraitValidator.java
@@ -1,0 +1,76 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.validation;
+
+import alloy.StructurePatternTrait;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.SimpleShape;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.traits.RequiredTrait;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class StructurePatternTraitValidator extends AbstractValidator {
+
+	@Override
+	public List<ValidationEvent> validate(Model model) {
+		List<ValidationEvent> events = new ArrayList<>();
+		model.getStringShapesWithTrait(StructurePatternTrait.class).forEach(patternShape -> {
+			StructurePatternTrait trt = patternShape.expectTrait(StructurePatternTrait.class);
+			List<String> patternParams = getParamNamesInPattern(trt.getPattern());
+			StructureShape struct = model.expectShape(trt.getTarget()).asStructureShape().get();
+			ArrayList<String> structureParamNames = new ArrayList<>(struct.getMemberNames());
+			structureParamNames.removeAll(patternParams);
+
+			if (!structureParamNames.isEmpty()) {
+				events.add(error(patternShape, "Did not find pattern params for the following members: "
+						+ String.join(", ", structureParamNames)));
+			}
+
+			struct.getAllMembers().forEach((key, value) -> {
+				Shape targetShape = model.expectShape(value.getTarget());
+				if (!(targetShape instanceof SimpleShape)) {
+					events.add(error(patternShape,
+							String.format("Pattern params must target simple shapes only, but '%s' targets '%s'", key,
+									targetShape.toShapeId())));
+				}
+                if (!value.hasTrait(RequiredTrait.class)) {
+                    events.add(error(patternShape, String.format("Pattern params must not target optional structure members, but '%s' is optional", key)));
+                }
+			});
+		});
+
+		return events;
+	}
+
+	private List<String> getParamNamesInPattern(String pattern) {
+		Pattern pat = Pattern.compile("\\{(.*?)}");
+		Matcher matcher = pat.matcher(pattern);
+		ArrayList<String> results = new ArrayList<>();
+		while (matcher.find()) {
+			for (int j = 0; j <= matcher.groupCount(); j++) {
+				results.add(matcher.group(j));
+			}
+		}
+		return results;
+	}
+}

--- a/modules/core/test/resources/META-INF/smithy/traits.smithy
+++ b/modules/core/test/resources/META-INF/smithy/traits.smithy
@@ -23,6 +23,7 @@ use alloy#untagged
 use alloy#uuidFormat
 use alloy#simpleRestJson
 use alloy#dataExamples
+use alloy#structurePattern
 
 @dateFormat
 string MyDate
@@ -150,4 +151,17 @@ structure TestJsonExamples {
 structure TestStringExamples {
     one: String
     two: Integer
+}
+
+@structurePattern(
+    pattern: "{test}__{test2}"
+    target: TestStructureTarget
+)
+string TestStructurePattern
+
+structure TestStructureTarget {
+    @required
+    test: String
+    @required
+    test2: String
 }

--- a/modules/core/test/src/alloy/validation/StructurePatternTraitValidatorSpec.scala
+++ b/modules/core/test/src/alloy/validation/StructurePatternTraitValidatorSpec.scala
@@ -1,0 +1,236 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.validation
+
+import alloy.StructurePatternTrait
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.shapes.StringShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.validation.ValidationEvent
+import software.amazon.smithy.model.validation.Severity
+import scala.jdk.CollectionConverters._
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.traits.RequiredTrait
+
+final class StructurePatternTraitValidatorSpec extends munit.FunSuite {
+
+  private val validator = new StructurePatternTraitValidator
+
+  test("no error") {
+    val targetId = ShapeId.fromParts("test", "MyStruct")
+    val patternTrait = StructurePatternTrait
+      .builder()
+      .setPattern("{one}-{two}")
+      .setTarget(targetId)
+      .build()
+    val stringShape = StringShape
+      .builder()
+      .id(ShapeId.fromParts("test", "MyString"))
+      .addTrait(patternTrait)
+      .build()
+    val structShape = StructureShape
+      .builder()
+      .id(targetId)
+      .addMember(
+        MemberShape
+          .builder()
+          .id(targetId.withMember("one"))
+          .target(ShapeId.fromParts("smithy.api", "String"))
+          .addTrait(new RequiredTrait)
+          .build()
+      )
+      .addMember(
+        MemberShape
+          .builder()
+          .id(targetId.withMember("two"))
+          .target(ShapeId.fromParts("smithy.api", "Integer"))
+          .addTrait(new RequiredTrait)
+          .build()
+      )
+      .build()
+
+    val model =
+      Model.assembler.disableValidation
+        .addShapes(structShape, stringShape)
+        .assemble()
+        .unwrap()
+
+    val result = validator.validate(model).asScala.toList
+
+    assertEquals(result, List.empty)
+  }
+
+  test("optional structure member") {
+    val targetId = ShapeId.fromParts("test", "MyStruct")
+    val patternTrait = StructurePatternTrait
+      .builder()
+      .setPattern("{one}")
+      .setTarget(targetId)
+      .build()
+    val stringShape = StringShape
+      .builder()
+      .id(ShapeId.fromParts("test", "MyString"))
+      .addTrait(patternTrait)
+      .build()
+    val structShape = StructureShape
+      .builder()
+      .id(targetId)
+      .addMember(
+        MemberShape
+          .builder()
+          .id(targetId.withMember("one"))
+          .target(ShapeId.fromParts("smithy.api", "String"))
+          .build()
+      )
+      .build()
+
+    val model =
+      Model.assembler.disableValidation
+        .addShapes(structShape, stringShape)
+        .assemble()
+        .unwrap()
+
+    val result = validator.validate(model).asScala.toList
+
+    val expected = List(
+      ValidationEvent
+        .builder()
+        .id("StructurePatternTrait")
+        .shape(stringShape)
+        .severity(Severity.ERROR)
+        .message(
+          "Pattern params must not target optional structure members, but 'one' is optional"
+        )
+        .build()
+    )
+    assertEquals(result, expected)
+  }
+
+  test("structure has one more param than pattern") {
+    val targetId = ShapeId.fromParts("test", "MyStruct")
+    val patternTrait = StructurePatternTrait
+      .builder()
+      .setPattern("{one}-{two}")
+      .setTarget(targetId)
+      .build()
+    val stringShape = StringShape
+      .builder()
+      .id(ShapeId.fromParts("test", "MyString"))
+      .addTrait(patternTrait)
+      .build()
+    val structShape = StructureShape
+      .builder()
+      .id(targetId)
+      .addMember(
+        MemberShape
+          .builder()
+          .id(targetId.withMember("one"))
+          .target(ShapeId.fromParts("smithy.api", "String"))
+          .addTrait(new RequiredTrait)
+          .build()
+      )
+      .addMember(
+        MemberShape
+          .builder()
+          .id(targetId.withMember("two"))
+          .target(ShapeId.fromParts("smithy.api", "Integer"))
+          .addTrait(new RequiredTrait)
+          .build()
+      )
+      .addMember(
+        MemberShape
+          .builder()
+          .id(targetId.withMember("three"))
+          .target(ShapeId.fromParts("smithy.api", "Long"))
+          .addTrait(new RequiredTrait)
+          .build()
+      )
+      .build()
+
+    val model =
+      Model.assembler.disableValidation
+        .addShapes(structShape, stringShape)
+        .assemble()
+        .unwrap()
+
+    val result = validator.validate(model).asScala.toList
+
+    val expected = List(
+      ValidationEvent
+        .builder()
+        .id("StructurePatternTrait")
+        .shape(stringShape)
+        .severity(Severity.ERROR)
+        .message(
+          "Did not find pattern params for the following members: three"
+        )
+        .build()
+    )
+    assertEquals(result, expected)
+  }
+
+  test("param non-simple shape") {
+    val targetId = ShapeId.fromParts("test", "MyStruct")
+    val patternTrait = StructurePatternTrait
+      .builder()
+      .setPattern("{one}")
+      .setTarget(targetId)
+      .build()
+    val stringShape = StringShape
+      .builder()
+      .id(ShapeId.fromParts("test", "MyString"))
+      .addTrait(patternTrait)
+      .build()
+    val otherStruct = StructureShape
+      .builder()
+      .id(ShapeId.fromParts("test", "OtherStruct"))
+      .build()
+    val structShape = StructureShape
+      .builder()
+      .id(targetId)
+      .addMember(
+        MemberShape
+          .builder()
+          .id(targetId.withMember("one"))
+          .target(otherStruct.toShapeId)
+          .addTrait(new RequiredTrait)
+          .build()
+      )
+      .build()
+
+    val model =
+      Model.assembler.disableValidation
+        .addShapes(otherStruct, structShape, stringShape)
+        .assemble()
+        .unwrap()
+
+    val result = validator.validate(model).asScala.toList
+
+    val expected = List(
+      ValidationEvent
+        .builder()
+        .id("StructurePatternTrait")
+        .shape(stringShape)
+        .severity(Severity.ERROR)
+        .message(
+          "Pattern params must target simple shapes only, but 'one' targets 'test#OtherStruct'"
+        )
+        .build()
+    )
+    assertEquals(result, expected)
+  }
+}


### PR DESCRIPTION
Adds a new trait `alloy#structurePattern` which can be used to map strings to structures. For example, a user can define a pattern `{foo}_{bar}` and have that string parsed into a structure with two required members, foo and bar, provided that foo and bar both target simple shapes.