### PR TITLE
Fix documentation validation failing with Smithy 1.31.0

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,4 @@
+updates.fileExtensions = [
+  "build.sc",
+  "smithy-build.json"
+]

--- a/modules/core/resources/META-INF/smithy/documentation.smithy
+++ b/modules/core/resources/META-INF/smithy/documentation.smithy
@@ -2,8 +2,8 @@ $version: "2"
 
 namespace alloy
 
-@trait(selector: "operation")
 /// A version of @examples that is not tied to a validator
+@trait(selector: "operation")
 list uncheckedExamples {
     member: UncheckedExample
 }

--- a/smithy-build.json
+++ b/smithy-build.json
@@ -2,7 +2,7 @@
   "imports": ["modules/core/resources", "modules/protocol-tests/resources"],
   "maven": {
     "dependencies": [
-      "software.amazon.smithy:smithy-protocol-test-traits:1.27.0"
+      "software.amazon.smithy:smithy-protocol-test-traits:1.31.0"
     ]
   }
 }


### PR DESCRIPTION
Also adds a Steward bumpability for the build file.