### PR TITLE
Change the configuration format

### DIFF
--- a/modules/protocol-tests/resources/META-INF/smithy/test-config.json
+++ b/modules/protocol-tests/resources/META-INF/smithy/test-config.json
@@ -455,20 +455,19 @@
         ],
         "disallowList": [
           {
-            "id": "RestJsonStreamingTraitsWithNoBlobBody",
-            "appliesTo": "client",
-            "description": "request"
+            "id": "RestJsonStreamingTraits**"
           },
           {
-            "id": "RestJsonStreamingTraitsRequireLengthWithNoBlobBody",
-            "appliesTo": "client",
-            "description": "request"
+            "id": "StringPayload**"
           },
           {
-            "id": "RestJsonHttpPayloadTraitsWithNoBlobBody"
+            "id": "EnumPayload**"
           },
           {
-            "id": "StringPayloadRequest"
+            "id": "RestJsonHttpWithEmptyBlobPayload"
+          },
+          {
+            "id": "RestJsonSupportsInfinity**"
           }
         ]
       }

--- a/modules/protocol-tests/resources/META-INF/smithy/test-config.json
+++ b/modules/protocol-tests/resources/META-INF/smithy/test-config.json
@@ -1,1592 +1,477 @@
 {
   "smithy": "2.0",
   "metadata": {
-    "alloyRestJsonAllowList": [
-      {
-        "id": "RestJsonNoInputAndNoOutput",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonAllQueryStringTypes",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonAllQueryStringTypes",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSupportsNaNFloatQueryValues",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSupportsInfinityFloatQueryValues",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSupportsNegativeInfinityFloatQueryValues",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonOmitsEmptyListQueryValues",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonOmitsEmptyListQueryValues",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonQueryIdempotencyTokenAutoFill",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonQueryIdempotencyTokenAutoFill",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "HttpPrefixHeadersResponse",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonServersQueryParamsStringListMap",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonServersPutAllQueryParamsInMap",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonQueryPrecedence",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonNoInputAndOutputWithJson",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonUnitInputAndOutputNoOutput",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonEmptyInputAndEmptyOutput",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonNoInputAndOutputNoPayload",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonEmptyInputAndEmptyOutputJsonObjectOutput",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonEmptyInputAndEmptyOutput",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonNoInputAndOutput",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonNoInputAndNoOutput",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonUnitInputAndOutput",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonHttpRequestWithGreedyLabelInPath",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonToleratesRegexCharsInSegments",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonTimestampFormatHeaders",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonQueryStringEscaping",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonQueryStringMap",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonConstantAndVariableQueryStringMissingOneValue",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonConstantQueryString",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonConstantAndVariableQueryStringAllValues",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonIgnoreQueryParamsInResponse",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonOmitsNullQuery",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializesEmptyQueryValue",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonHttpPrefixHeadersArePresent",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonQueryParamsStringListMap",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonHttpPrefixHeadersAreNotPresent",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonHttpPrefixHeadersArePresent",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonHttpPayloadTraitsWithNoBlobBody",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonDoesntSerializeNullStructureValues",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonDoesntDeserializeNullStructureValues",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSimpleScalarProperties",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSimpleScalarProperties",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithDateTimeOnTargetFormat",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithEpochSecondsFormat",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithDateTimeFormat",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithEpochSecondsOnTargetFormat",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithDateTimeFormat",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithHttpDateOnTargetFormat",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithHttpDateFormat",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithEpochSecondsFormat",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithHttpDateOnTargetFormat",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithDateTimeOnTargetFormat",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithEpochSecondsOnTargetFormat",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithHttpDateFormat",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonRecursiveShapes",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonIntEnums",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonEnums",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonLists",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonListsEmpty",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonRecursiveShapes",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonIntEnums",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonEnums",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonListsEmpty",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonLists",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializesZeroValuesInMaps",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSerializesDenseSetMap",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonMaps",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializesSparseSetMap",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonMaps",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializesSparseSetMap",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializesZeroValuesInMaps",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonDeserializesDenseSetMap",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "DocumentTypeInputWithObject",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "DocumentInputWithString",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "DocumentInputWithNumber",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "DocumentOutputBoolean",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "DocumentOutputNumber",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "DocumentTypeAsPayloadInput",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "DocumentInputWithList",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "DocumentOutputString",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "DocumentOutput",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "DocumentOutputArray",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "DocumentTypeAsPayloadInputString",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "DocumentInputWithBoolean",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "DocumentTypeAsPayloadOutput",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "DocumentTypeAsPayloadOutputString",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSerializeNumberUnionValue",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializeListUnionValue",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializeBooleanUnionValue",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializeStringUnionValue",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializeStructureUnionValue",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializeEnumUnionValue",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializeMapUnionValue",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonDeserializeListUnionValue",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializeMapUnionValue",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializeNumberUnionValue",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializeStructureUnionValue",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializeBooleanUnionValue",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializeStringUnionValue",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializeEnumUnionValue",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "PostUnionWithJsonNameRequest1",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "PostUnionWithJsonNameRequest3",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonInputUnionWithUnitMember",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "PostUnionWithJsonNameRequest2",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonOutputUnionWithUnitMember",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "PostUnionWithJsonNameResponse1",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "PostUnionWithJsonNameResponse2",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "PostUnionWithJsonNameResponse3",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonEndpointTrait",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonTestBodyStructure",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonTestPayloadStructure",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonEndpointTraitWithHostLabel",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonHttpWithEmptyBody",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonNoInputAndNoOutput",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonUnitInputAndOutputNoOutput",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonNoInputAndOutputAllowsAccept",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonNoInputAndNoOutput",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonEmptyInputAndEmptyOutputWithJson",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonUnitInputAllowsAccept",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonUnitInputAndOutput",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonEmptyInputAndEmptyOutput",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonNoInputAllowsAccept",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonTimestampFormatHeaders",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonNoInputAndOutput",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonHttpRequestWithLabelsAndTimestampFormat",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonHttpRequestLabelEscaping",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonInputAndOutputWithStringHeaders",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonInputAndOutputWithIntEnumHeaders",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonInputAndOutputWithNumericHeaders",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonInputAndOutputWithEnumHeaders",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonInputAndOutputWithBooleanHeaders",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonInputAndOutputWithStringHeaders",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonInputAndOutputWithNumericHeaders",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonInputAndOutputWithBooleanHeaders",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonInputAndOutputWithEnumHeaders",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonInputAndOutputWithIntEnumHeaders",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonInputWithHeadersAndAllParams",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonToleratesRegexCharsInSegments",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonHttpRequestWithGreedyLabelInPath",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonQueryStringEscaping",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonQueryStringMap",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonIgnoreQueryParamsInResponse",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonServersAcceptStaticQueryParamAsEmptyString",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonConstantAndVariableQueryStringAllValues",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonConstantQueryString",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonConstantAndVariableQueryStringMissingOneValue",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonHttpPrefixHeadersArePresent",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSerializesEmptyQueryValue",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "HttpPrefixHeadersResponse",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonHttpPayloadTraitsWithNoBlobBody",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonHttpPayloadWithStructure",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonHttpPrefixHeadersArePresent",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonHttpPayloadWithStructure",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonServersDontSerializeNullStructureValues",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSimpleScalarProperties",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonServersDontSerializeNullStructureValues",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSimpleScalarProperties",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithHttpDateFormat",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithEpochSecondsFormat",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithDateTimeOnTargetFormat",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithHttpDateFormat",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithEpochSecondsOnTargetFormat",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithDateTimeFormat",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithDateTimeOnTargetFormat",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithEpochSecondsFormat",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithDateTimeFormat",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithHttpDateOnTargetFormat",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithEpochSecondsOnTargetFormat",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonTimestampsWithHttpDateOnTargetFormat",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonRecursiveShapes",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonEnums",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonIntEnums",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonEnums",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonIntEnums",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonListsEmpty",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonLists",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonRecursiveShapes",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonListsEmpty",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonLists",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSerializesDenseSetMap",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializesSparseSetMap",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonMaps",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializesZeroValuesInMaps",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonMaps",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializesSparseSetMap",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializesDenseSetMap",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializesZeroValuesInMaps",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "DocumentOutput",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "DocumentOutputNumber",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "DocumentOutputString",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "DocumentOutputBoolean",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "DocumentTypeAsPayloadOutput",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "DocumentTypeAsPayloadOutputString",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "DocumentInputWithString",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "DocumentInputWithNumber",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "DocumentTypeInputWithObject",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "DocumentOutputArray",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "DocumentTypeAsPayloadInputString",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "DocumentTypeAsPayloadInput",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "DocumentInputWithBoolean",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "DocumentInputWithList",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonDeserializeStringUnionValue",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSerializeStructureUnionValue",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializeMapUnionValue",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializeEnumUnionValue",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonDeserializeBooleanUnionValue",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSerializeListUnionValue",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializeStringUnionValue",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializeNumberUnionValue",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializeBooleanUnionValue",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonDeserializeNumberUnionValue",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializeListUnionValue",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializeMapUnionValue",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializeStructureUnionValue",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonOutputUnionWithUnitMember",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializeEnumUnionValue",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonInputUnionWithUnitMember",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonEndpointTrait",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "PostUnionWithJsonNameRequest3",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "PostUnionWithJsonNameRequest1",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "PostUnionWithJsonNameRequest2",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonEndpointTraitWithHostLabel",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "PostUnionWithJsonNameResponse3",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "PostUnionWithJsonNameResponse2",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "PostUnionWithJsonNameResponse1",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonTestBodyStructure",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonHttpWithNoModeledBody",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonHttpWithNoModeledBody",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonTestPayloadStructure",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonHttpWithEmptyBody",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSupportsNaNFloatQueryValues",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonHttpWithHeaderMemberNoModeledBody",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonHttpWithHeaderMemberNoModeledBody",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonHttpResponseCodeWithNoPayload",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonHttpResponseCode",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonHttpPayloadWithStructure",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonHttpPayloadWithStructure",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonEmptyComplexErrorWithNoMessage",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonInvalidGreetingError",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonGreetingWithErrorsNoPayload",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonGreetingWithErrors",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSerializeRenamedStructureUnionValue",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonQueryIdempotencyTokenAutoFillIsSet",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonStreamingTraitsWithNoBlobBody",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonStreamingTraitsRequireLengthWithNoBlobBody",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonHttpChecksumRequired",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializeRenamedStructureUnionValue",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonStreamingTraitsWithNoBlobBody",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSerializeBlobUnionValue",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "JsonUnions",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "JsonUnions",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonGreetingWithErrors",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSerializeTimestampUnionValue",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonDeserializeBlobUnionValue",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializeTimestampUnionValue",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonTimestamps",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonTimestamps",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonDeserializeTimestampUnionValue",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonDeserializeTimestampUnionValue",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonTimestamps",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonTimestamps",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "StringPayloadRequest",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "EnumPayloadRequest",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializeTimestampUnionValue",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonDateTimeWithFractionalSeconds",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonHttpDateWithFractionalSeconds",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSupportsNaNFloatHeaderInputs",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonHostWithPath",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonDateTimeWithNegativeOffset",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDateTimeWithPositiveOffset",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSupportsNaNFloatHeaderInputs",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSupportsInfinityFloatHeaderInputs",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSupportsNegativeInfinityFloatHeaderInputs",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSupportsInfinityFloatHeaderOutputs",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSupportsNegativeInfinityFloatHeaderOutputs",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSupportsNaNFloatLabels",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSupportsNaNFloatLabels",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSupportsInfinityFloatLabels",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSupportsNegativeInfinityFloatLabels",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonBlobs",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonJsonBlobs",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonDeserializeBlobUnionValue",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSupportsInfinityFloatHeaderInputs",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSupportsNegativeInfinityFloatHeaderInputs",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSupportsNaNFloatHeaderOutputs",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSupportsNaNFloatHeaderOutputs",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonComplexErrorWithNoMessage",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSupportsInfinityFloatHeaderOutputs",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSupportsNegativeInfinityFloatHeaderOutputs",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSupportsInfinityFloatLabels",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSupportsNegativeInfinityFloatLabels",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSupportsInfinityFloatQueryValues",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSupportsNegativeInfinityFloatQueryValues",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonBlobs",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonJsonBlobs",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSerializeBlobUnionValue",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonListsSerializeNull",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonListsSerializeNull",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonListsSerializeNull",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonListsSerializeNull",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSerializesNullMapValues",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializesNullMapValues",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSerializesNullMapValues",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializesNullMapValues",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSerializesSparseSetMapAndRetainsNull",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializesSparseSetMapAndRetainsNull",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonSerializesSparseSetMapAndRetainsNull",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonSerializesSparseSetMapAndRetainsNull",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializesSparseSetMapAndRetainsNull",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonDeserializesSparseSetMapAndRetainsNull",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializesSparseSetMapAndRetainsNull",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonDeserializesSparseSetMapAndRetainsNull",
-        "appliesTo": "client",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializesNullMapValues",
-        "appliesTo": "server",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonDeserializesNullMapValues",
-        "appliesTo": "server",
-        "description": "response"
-      },
-      {
-        "id": "RestJsonDeserializesNullMapValues",
-        "appliesTo": "client",
-        "description": "request"
-      },
-      {
-        "id": "RestJsonDeserializesNullMapValues",
-        "appliesTo": "client",
-        "description": "response"
+    "alloySimpleRestJsonBorrowedTests": {
+      "aws.protocols#restJson1": {
+        "allowList": [
+          {
+            "id": "RestJsonNoInputAndNoOutput"
+          },
+          {
+            "id": "RestJsonAllQueryStringTypes"
+          },
+          {
+            "id": "RestJsonSupportsNaNFloatQueryValues"
+          },
+          {
+            "id": "RestJsonSupportsInfinityFloatQueryValues"
+          },
+          {
+            "id": "RestJsonSupportsNegativeInfinityFloatQueryValues"
+          },
+          {
+            "id": "RestJsonOmitsEmptyListQueryValues"
+          },
+          {
+            "id": "RestJsonQueryIdempotencyTokenAutoFill"
+          },
+          {
+            "id": "HttpPrefixHeadersResponse"
+          },
+          {
+            "id": "RestJsonServersQueryParamsStringListMap"
+          },
+          {
+            "id": "RestJsonServersPutAllQueryParamsInMap"
+          },
+          {
+            "id": "RestJsonQueryPrecedence"
+          },
+          {
+            "id": "RestJsonNoInputAndOutputWithJson"
+          },
+          {
+            "id": "RestJsonUnitInputAndOutputNoOutput"
+          },
+          {
+            "id": "RestJsonEmptyInputAndEmptyOutput"
+          },
+          {
+            "id": "RestJsonNoInputAndOutputNoPayload"
+          },
+          {
+            "id": "RestJsonEmptyInputAndEmptyOutputJsonObjectOutput"
+          },
+          {
+            "id": "RestJsonNoInputAndOutput"
+          },
+          {
+            "id": "RestJsonUnitInputAndOutput"
+          },
+          {
+            "id": "RestJsonHttpRequestWithGreedyLabelInPath"
+          },
+          {
+            "id": "RestJsonToleratesRegexCharsInSegments"
+          },
+          {
+            "id": "RestJsonTimestampFormatHeaders"
+          },
+          {
+            "id": "RestJsonQueryStringEscaping"
+          },
+          {
+            "id": "RestJsonQueryStringMap"
+          },
+          {
+            "id": "RestJsonConstantAndVariableQueryStringMissingOneValue"
+          },
+          {
+            "id": "RestJsonConstantQueryString"
+          },
+          {
+            "id": "RestJsonConstantAndVariableQueryStringAllValues"
+          },
+          {
+            "id": "RestJsonIgnoreQueryParamsInResponse"
+          },
+          {
+            "id": "RestJsonOmitsNullQuery"
+          },
+          {
+            "id": "RestJsonSerializesEmptyQueryValue"
+          },
+          {
+            "id": "RestJsonHttpPrefixHeadersArePresent"
+          },
+          {
+            "id": "RestJsonQueryParamsStringListMap"
+          },
+          {
+            "id": "RestJsonHttpPrefixHeadersAreNotPresent"
+          },
+          {
+            "id": "RestJsonDoesntSerializeNullStructureValues"
+          },
+          {
+            "id": "RestJsonDoesntDeserializeNullStructureValues"
+          },
+          {
+            "id": "RestJsonSimpleScalarProperties"
+          },
+          {
+            "id": "RestJsonJsonTimestampsWithDateTimeOnTargetFormat"
+          },
+          {
+            "id": "RestJsonJsonTimestampsWithEpochSecondsFormat"
+          },
+          {
+            "id": "RestJsonJsonTimestampsWithDateTimeFormat"
+          },
+          {
+            "id": "RestJsonJsonTimestampsWithEpochSecondsOnTargetFormat"
+          },
+          {
+            "id": "RestJsonJsonTimestampsWithHttpDateOnTargetFormat"
+          },
+          {
+            "id": "RestJsonJsonTimestampsWithHttpDateFormat"
+          },
+          {
+            "id": "RestJsonRecursiveShapes"
+          },
+          {
+            "id": "RestJsonJsonIntEnums"
+          },
+          {
+            "id": "RestJsonJsonEnums"
+          },
+          {
+            "id": "RestJsonLists"
+          },
+          {
+            "id": "RestJsonListsEmpty"
+          },
+          {
+            "id": "RestJsonDeserializesZeroValuesInMaps"
+          },
+          {
+            "id": "RestJsonSerializesDenseSetMap"
+          },
+          {
+            "id": "RestJsonJsonMaps"
+          },
+          {
+            "id": "RestJsonDeserializesSparseSetMap"
+          },
+          {
+            "id": "RestJsonSerializesSparseSetMap"
+          },
+          {
+            "id": "RestJsonSerializesZeroValuesInMaps"
+          },
+          {
+            "id": "RestJsonDeserializesDenseSetMap"
+          },
+          {
+            "id": "DocumentTypeInputWithObject"
+          },
+          {
+            "id": "DocumentInputWithString"
+          },
+          {
+            "id": "DocumentInputWithNumber"
+          },
+          {
+            "id": "DocumentOutputBoolean"
+          },
+          {
+            "id": "DocumentOutputNumber"
+          },
+          {
+            "id": "DocumentTypeAsPayloadInput"
+          },
+          {
+            "id": "DocumentInputWithList"
+          },
+          {
+            "id": "DocumentOutputString"
+          },
+          {
+            "id": "DocumentOutput"
+          },
+          {
+            "id": "DocumentOutputArray"
+          },
+          {
+            "id": "DocumentTypeAsPayloadInputString"
+          },
+          {
+            "id": "DocumentInputWithBoolean"
+          },
+          {
+            "id": "DocumentTypeAsPayloadOutput"
+          },
+          {
+            "id": "DocumentTypeAsPayloadOutputString"
+          },
+          {
+            "id": "RestJsonSerializeNumberUnionValue"
+          },
+          {
+            "id": "RestJsonSerializeListUnionValue"
+          },
+          {
+            "id": "RestJsonSerializeBooleanUnionValue"
+          },
+          {
+            "id": "RestJsonSerializeStringUnionValue"
+          },
+          {
+            "id": "RestJsonSerializeStructureUnionValue"
+          },
+          {
+            "id": "RestJsonSerializeEnumUnionValue"
+          },
+          {
+            "id": "RestJsonSerializeMapUnionValue"
+          },
+          {
+            "id": "RestJsonDeserializeListUnionValue"
+          },
+          {
+            "id": "RestJsonDeserializeMapUnionValue"
+          },
+          {
+            "id": "RestJsonDeserializeNumberUnionValue"
+          },
+          {
+            "id": "RestJsonDeserializeStructureUnionValue"
+          },
+          {
+            "id": "RestJsonDeserializeBooleanUnionValue"
+          },
+          {
+            "id": "RestJsonDeserializeStringUnionValue"
+          },
+          {
+            "id": "RestJsonDeserializeEnumUnionValue"
+          },
+          {
+            "id": "PostUnionWithJsonNameRequest1"
+          },
+          {
+            "id": "PostUnionWithJsonNameRequest3"
+          },
+          {
+            "id": "RestJsonInputUnionWithUnitMember"
+          },
+          {
+            "id": "PostUnionWithJsonNameRequest2"
+          },
+          {
+            "id": "RestJsonOutputUnionWithUnitMember"
+          },
+          {
+            "id": "PostUnionWithJsonNameResponse1"
+          },
+          {
+            "id": "PostUnionWithJsonNameResponse2"
+          },
+          {
+            "id": "PostUnionWithJsonNameResponse3"
+          },
+          {
+            "id": "RestJsonEndpointTrait"
+          },
+          {
+            "id": "RestJsonTestBodyStructure"
+          },
+          {
+            "id": "RestJsonTestPayloadStructure"
+          },
+          {
+            "id": "RestJsonEndpointTraitWithHostLabel"
+          },
+          {
+            "id": "RestJsonHttpWithEmptyBody"
+          },
+          {
+            "id": "RestJsonNoInputAndOutputAllowsAccept"
+          },
+          {
+            "id": "RestJsonEmptyInputAndEmptyOutputWithJson"
+          },
+          {
+            "id": "RestJsonUnitInputAllowsAccept"
+          },
+          {
+            "id": "RestJsonNoInputAllowsAccept"
+          },
+          {
+            "id": "RestJsonHttpRequestWithLabelsAndTimestampFormat"
+          },
+          {
+            "id": "RestJsonHttpRequestLabelEscaping"
+          },
+          {
+            "id": "RestJsonInputAndOutputWithStringHeaders",
+            "appliesTo": "client",
+            "testType": "response"
+          },
+          {
+            "id": "RestJsonInputAndOutputWithStringHeaders",
+            "appliesTo": "server",
+            "testType": "request"
+          },
+          {
+            "id": "RestJsonInputAndOutputWithIntEnumHeaders"
+          },
+          {
+            "id": "RestJsonInputAndOutputWithNumericHeaders"
+          },
+          {
+            "id": "RestJsonInputAndOutputWithEnumHeaders"
+          },
+          {
+            "id": "RestJsonInputAndOutputWithBooleanHeaders"
+          },
+          {
+            "id": "RestJsonInputWithHeadersAndAllParams"
+          },
+          {
+            "id": "RestJsonServersAcceptStaticQueryParamAsEmptyString"
+          },
+          {
+            "id": "RestJsonHttpPayloadWithStructure"
+          },
+          {
+            "id": "RestJsonServersDontSerializeNullStructureValues"
+          },
+          {
+            "id": "RestJsonHttpWithNoModeledBody"
+          },
+          {
+            "id": "RestJsonHttpWithHeaderMemberNoModeledBody"
+          },
+          {
+            "id": "RestJsonHttpResponseCodeWithNoPayload"
+          },
+          {
+            "id": "RestJsonHttpResponseCode"
+          },
+          {
+            "id": "RestJsonEmptyComplexErrorWithNoMessage"
+          },
+          {
+            "id": "RestJsonInvalidGreetingError"
+          },
+          {
+            "id": "RestJsonGreetingWithErrorsNoPayload"
+          },
+          {
+            "id": "RestJsonGreetingWithErrors"
+          },
+          {
+            "id": "RestJsonSerializeRenamedStructureUnionValue"
+          },
+          {
+            "id": "RestJsonQueryIdempotencyTokenAutoFillIsSet"
+          },
+          {
+            "id": "RestJsonSerializeBlobUnionValue"
+          },
+          {
+            "id": "JsonUnions"
+          },
+          {
+            "id": "RestJsonSerializeTimestampUnionValue"
+          },
+          {
+            "id": "RestJsonDeserializeBlobUnionValue"
+          },
+          {
+            "id": "RestJsonDeserializeTimestampUnionValue"
+          },
+          {
+            "id": "RestJsonJsonTimestamps"
+          },
+          {
+            "id": "EnumPayloadRequest"
+          },
+          {
+            "id": "RestJsonDateTimeWithFractionalSeconds"
+          },
+          {
+            "id": "RestJsonHttpDateWithFractionalSeconds"
+          },
+          {
+            "id": "RestJsonSupportsNaNFloatHeaderInputs"
+          },
+          {
+            "id": "RestJsonHostWithPath"
+          },
+          {
+            "id": "RestJsonDateTimeWithNegativeOffset"
+          },
+          {
+            "id": "RestJsonDateTimeWithPositiveOffset"
+          },
+          {
+            "id": "RestJsonSupportsInfinityFloatHeaderInputs"
+          },
+          {
+            "id": "RestJsonSupportsNegativeInfinityFloatHeaderInputs"
+          },
+          {
+            "id": "RestJsonSupportsInfinityFloatHeaderOutputs"
+          },
+          {
+            "id": "RestJsonSupportsNegativeInfinityFloatHeaderOutputs"
+          },
+          {
+            "id": "RestJsonSupportsNaNFloatLabels"
+          },
+          {
+            "id": "RestJsonSupportsInfinityFloatLabels"
+          },
+          {
+            "id": "RestJsonSupportsNegativeInfinityFloatLabels"
+          },
+          {
+            "id": "RestJsonJsonBlobs"
+          },
+          {
+            "id": "RestJsonSupportsNaNFloatHeaderOutputs"
+          },
+          {
+            "id": "RestJsonComplexErrorWithNoMessage"
+          },
+          {
+            "id": "RestJsonListsSerializeNull"
+          },
+          {
+            "id": "RestJsonSerializesNullMapValues"
+          },
+          {
+            "id": "RestJsonSerializesSparseSetMapAndRetainsNull"
+          },
+          {
+            "id": "RestJsonDeserializesSparseSetMapAndRetainsNull"
+          },
+          {
+            "id": "RestJsonDeserializesNullMapValues"
+          }
+        ],
+        "disallowList": [
+          {
+            "id": "RestJsonStreamingTraitsWithNoBlobBody",
+            "appliesTo": "client",
+            "description": "request"
+          },
+          {
+            "id": "RestJsonStreamingTraitsRequireLengthWithNoBlobBody",
+            "appliesTo": "client",
+            "description": "request"
+          },
+          {
+            "id": "RestJsonHttpPayloadTraitsWithNoBlobBody"
+          },
+          {
+            "id": "StringPayloadRequest"
+          }
+        ]
       }
-    ]
+    }
   }
 }

--- a/modules/protocol-tests/resources/META-INF/smithy/test-config.json
+++ b/modules/protocol-tests/resources/META-INF/smithy/test-config.json
@@ -483,6 +483,22 @@
             "why": "Absence of value and empty array are not the same things",
             "appliesTo": "server",
             "testType": "request"
+          },
+          {
+            "id": "RestJsonTestPayloadBlob",
+            "why": "Custom media types aren't supported in simpleRestJson"
+          },
+          {
+            "id": "RestJsonHttpPayloadTraitsWithBlobAcceptsAllContentTypes",
+            "why": "Custom media types aren't supported in simpleRestJson"
+          },
+          {
+            "id": "RestJsonHttpPayloadTraitsWithBlobAcceptsAllAccepts",
+            "why": "Custom media types aren't supported in simpleRestJson"
+          },
+          {
+            "id": "RestJsonHttpPayloadTraitsWithMediaTypeWithBlob",
+            "why": "Custom media types aren't supported in simpleRestJson"
           }
         ]
       }

--- a/modules/protocol-tests/resources/META-INF/smithy/test-config.json
+++ b/modules/protocol-tests/resources/META-INF/smithy/test-config.json
@@ -11,12 +11,6 @@
             "id": "RestJsonAllQueryStringTypes"
           },
           {
-            "id": "RestJsonSupportsNaNFloatQueryValues"
-          },
-          {
-            "id": "RestJsonSupportsInfinityFloatQueryValues"
-          },
-          {
             "id": "RestJsonSupportsNegativeInfinityFloatQueryValues"
           },
           {
@@ -305,28 +299,6 @@
             "id": "RestJsonHttpRequestLabelEscaping"
           },
           {
-            "id": "RestJsonInputAndOutputWithStringHeaders",
-            "appliesTo": "client",
-            "testType": "response"
-          },
-          {
-            "id": "RestJsonInputAndOutputWithStringHeaders",
-            "appliesTo": "server",
-            "testType": "request"
-          },
-          {
-            "id": "RestJsonInputAndOutputWithIntEnumHeaders"
-          },
-          {
-            "id": "RestJsonInputAndOutputWithNumericHeaders"
-          },
-          {
-            "id": "RestJsonInputAndOutputWithEnumHeaders"
-          },
-          {
-            "id": "RestJsonInputAndOutputWithBooleanHeaders"
-          },
-          {
             "id": "RestJsonInputWithHeadersAndAllParams"
           },
           {
@@ -396,9 +368,6 @@
             "id": "RestJsonHttpDateWithFractionalSeconds"
           },
           {
-            "id": "RestJsonSupportsNaNFloatHeaderInputs"
-          },
-          {
             "id": "RestJsonHostWithPath"
           },
           {
@@ -408,31 +377,16 @@
             "id": "RestJsonDateTimeWithPositiveOffset"
           },
           {
-            "id": "RestJsonSupportsInfinityFloatHeaderInputs"
-          },
-          {
             "id": "RestJsonSupportsNegativeInfinityFloatHeaderInputs"
           },
           {
-            "id": "RestJsonSupportsInfinityFloatHeaderOutputs"
-          },
-          {
             "id": "RestJsonSupportsNegativeInfinityFloatHeaderOutputs"
-          },
-          {
-            "id": "RestJsonSupportsNaNFloatLabels"
-          },
-          {
-            "id": "RestJsonSupportsInfinityFloatLabels"
           },
           {
             "id": "RestJsonSupportsNegativeInfinityFloatLabels"
           },
           {
             "id": "RestJsonJsonBlobs"
-          },
-          {
-            "id": "RestJsonSupportsNaNFloatHeaderOutputs"
           },
           {
             "id": "RestJsonComplexErrorWithNoMessage"
@@ -451,23 +405,84 @@
           },
           {
             "id": "RestJsonDeserializesNullMapValues"
+          },
+          {
+            "id": "RestJsonInputAndOutputWith*Headers"
+          },
+          {
+            "id": "RestJsonHttpResponseCodeDefaultsToModeledCode"
           }
         ],
         "disallowList": [
           {
-            "id": "RestJsonStreamingTraits**"
+            "id": "RestJsonHttpPayloadTraitsWithNoBlobBody",
+            "why": "Blobs are expected to be serialised as Base64 json strings in SimpleRestJson"
           },
           {
-            "id": "StringPayload**"
+            "id": "RestJsonHttpPayloadTraitsWithBlob",
+            "why": "SimpleRestJson forces the presence of a payload when there should be one"
           },
           {
-            "id": "EnumPayload**"
+            "id": "RestJsonStreamingTraits**",
+            "why": "Streaming is not supported in simpleRestJson"
           },
           {
-            "id": "RestJsonHttpWithEmptyBlobPayload"
+            "id": "StringPayload**",
+            "why": "Only json payloads are supported in simpleRestJson"
           },
           {
-            "id": "RestJsonSupportsInfinity**"
+            "id": "EnumPayload**",
+            "why": "Only json payloads are supported in simpleRestJson"
+          },
+          {
+            "id": "RestJsonHttpWithEmptyBlobPayload",
+            "why": "Only json payloads are supported in simpleRestJson"
+          },
+          {
+            "id": "RestJsonSupports*Infinity**",
+            "why": "Infinity parsing not supported for performance reason"
+          },
+          {
+            "id": "RestJsonSupportsNaN**",
+            "why": "Not-a-number parsing not supported for performance reason"
+          },
+          {
+            "id": "RestJsonInputAndOutputWith*Headers",
+            "why": "Impossible comparison between result and expectations: https://github.com/awslabs/smithy/pull/1798",
+            "appliesTo": "server",
+            "testType": "response"
+          },
+          {
+            "id": "RestJsonInputAndOutputWith*Headers",
+            "why": "Impossible comparison between result and expectations: https://github.com/awslabs/smithy/pull/1798",
+            "appliesTo": "client",
+            "testType": "request"
+          },
+          {
+            "id": "RestJsonInputAndOutputWithTimestampHeaders",
+            "why": "http-date headers aren't quoted: https://github.com/awslabs/smithy/pull/1798"
+          },
+          {
+            "id": "TimestampFormatHeaders",
+            "why": "http-date headers aren't quoted: https://github.com/awslabs/smithy/pull/1798"
+          },
+          {
+            "id": "RestJsonTimestampFormatHeaders",
+            "why": "http-date headers aren't quoted: https://github.com/awslabs/smithy/pull/1798",
+            "appliesTo": "server",
+            "testType": "request"
+          },
+          {
+            "id": "RestJsonTimestampFormatHeaders",
+            "why": "http-date headers aren't quoted: https://github.com/awslabs/smithy/pull/1798",
+            "appliesTo": "client",
+            "testType": "response"
+          },
+          {
+            "id": "RestJsonOmitsEmptyListQueryValues",
+            "why": "Absence of value and empty array are not the same things",
+            "appliesTo": "server",
+            "testType": "request"
           }
         ]
       }


### PR DESCRIPTION
1. Make the protocol we're borrowing tests from explicit
2. Make some parameters optional
3. Allow to disallow tests altogether
4. Tweak the names