### PR TITLE
Change body assertion from custom code output

### DIFF
--- a/modules/protocol-tests/resources/META-INF/smithy/CustomCode.smithy
+++ b/modules/protocol-tests/resources/META-INF/smithy/CustomCode.smithy
@@ -2,33 +2,30 @@ $version: "2"
 
 namespace alloy.test
 
-use alloy.test#CustomCode
 use alloy#simpleRestJson
+use alloy.test#CustomCode
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
-apply CustomCode @httpRequestTests([
-    {
-        id: "CustomCodeInput"
-        documentation: "tests custom code as a label",
-        protocol: simpleRestJson
-        uri: "/custom-code/399"
-        method: "GET"
-        body: ""
-        params: {
-            "code": 399
-        }
+apply CustomCode @httpRequestTests([{
+    id: "CustomCodeInput"
+    documentation: "tests custom code as a label"
+    protocol: simpleRestJson
+    uri: "/custom-code/399"
+    method: "GET"
+    body: ""
+    params: {
+        "code": 399
     }
-])
-apply CustomCode @httpResponseTests([
-    {
-        id: "CustomCodeOutput"
-        documentation: "respect the httpResponseCode trait",
-        protocol: simpleRestJson
-        code: 399
-        body: ""
-        params: {
-            "code": 399
-        }
+}])
+
+apply CustomCode @httpResponseTests([{
+    id: "CustomCodeOutput"
+    documentation: "respect the httpResponseCode trait"
+    protocol: simpleRestJson
+    code: 399
+    body: "{}"
+    params: {
+        "code": 399
     }
-])
+}])


### PR DESCRIPTION
Servers are now expected to send empty json bodies even when no fields are bound to the body, unless the output of an operation is Unit