### PR TITLE
change unsuppoprted traits from error to warn

### DIFF
--- a/modules/openapi/src/alloy/openapi/package.scala
+++ b/modules/openapi/src/alloy/openapi/package.scala
@@ -82,6 +82,7 @@ package object openapi {
         val config = new OpenApiConfig()
         config.setService(serviceId)
         config.setProtocol(protocol)
+        config.setIgnoreUnsupportedTraits(true)
         val openapi = OpenApiConverter.create().config(config).convert(model)
         val jsonString = Node.prettyPrintJson(openapi.toNode())
         OpenApiConversionResult(protocol, serviceId, jsonString)


### PR DESCRIPTION
current behavior is to fail conversion when encountering an unsupported trait
this switches it to warn 