### PR TITLE
support openEnum trait on String with @enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ Specifies that an enumeration is open meaning that it can accept "unknown" value
 This trait should be mainly be used for interop with external libraries that require it. Often a string or integer type may be more applicable if there are many different
 possible values that the API can return.
 
-This trait can be applied to `enum` or `intEnum` shapes.
+This trait can be applied to `enum` or `intEnum` shapes. Additionally it can be used on String shapes with the `smithy.api#enum` trait. This is supported for backward compatibility since the `enum` constraint trait is deprecated.
 
 ```smithy
 @openEnum

--- a/modules/core/resources/META-INF/smithy/enums.smithy
+++ b/modules/core/resources/META-INF/smithy/enums.smithy
@@ -5,5 +5,5 @@ namespace alloy
 /// Specifies that an enumeration is open meaning that
 /// it can accept "unknown" values that are not explicitly
 /// specified inside of the smithy enum shape definition.
-@trait(selector: ":test(enum, intEnum)")
+@trait(selector: ":test(enum, intEnum, [trait|enum])")
 structure openEnum {}

--- a/modules/core/test/resources/META-INF/smithy/traits.smithy
+++ b/modules/core/test/resources/META-INF/smithy/traits.smithy
@@ -176,3 +176,7 @@ enum TestOpenEnum {
 intEnum TestOpenIntEnum {
     ONE = 1
 }
+
+@openEnum
+@enum([{value: "A", name: "A"}])
+string TestOpenEnumTraitEnum


### PR DESCRIPTION
Supported for the purpose of backward compatibility with specs that still use the enum trait despite it being deprecated.