### PR TITLE
fix issue with openapi header timestamp formats

### DIFF
--- a/modules/openapi/test/resources/foo.json
+++ b/modules/openapi/test/resources/foo.json
@@ -66,6 +66,22 @@
             }
           },
           {
+            "name": "whenThree",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "whenFour",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "format": "epoch-seconds"
+            }
+          },
+          {
             "name": "X-Bamtech-Partner",
             "in": "header",
             "schema": {
@@ -74,6 +90,14 @@
           },
           {
             "name": "when",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "format": "http-date"
+            }
+          },
+          {
+            "name": "whenAlso",
             "in": "header",
             "schema": {
               "type": "string",

--- a/modules/openapi/test/resources/foo.smithy
+++ b/modules/openapi/test/resources/foo.smithy
@@ -50,7 +50,19 @@ structure Person {
   @httpHeader("when")
   when: Timestamp,
 
-@httpQuery("from")
+  @httpHeader("whenAlso")
+  @timestampFormat("http-date")
+  whenTwo: Timestamp,
+
+  @httpHeader("whenThree")
+  @timestampFormat("date-time")
+  whenThree: Timestamp,
+
+  @httpHeader("whenFour")
+  @timestampFormat("epoch-seconds")
+  whenFour: Timestamp,
+
+  @httpQuery("from")
   from: Timestamp,
 
   @httpLabel


### PR DESCRIPTION
Fixes an issue where Timestamp headers with timestampFormat traits were being ignored in the smithy => openapi conversion.