### PR TITLE
Protobuf specification rework 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ modules/website/static/api
 *.hnir
 
 .bsp
+
+# smithy LSP
+build/smithy
+.smithy.lsp.log

--- a/build.sc
+++ b/build.sc
@@ -141,6 +141,10 @@ object core extends BaseJavaModule {
   }
 }
 
+object protobuf extends BaseJavaModule {
+  
+}
+
 val scalaVersionsMap =
   Map("2.13" -> "2.13.7", "2.12" -> "2.12.17", "3" -> "3.3.0")
 object openapi extends Cross[OpenapiModule](scalaVersionsMap.keys.toList)

--- a/docs/protocols/gRPC.md
+++ b/docs/protocols/gRPC.md
@@ -6,6 +6,8 @@ The following traits should be taken into consideration by implementors of the p
 
 - alloy.proto#protoIndex
 - alloy.proto#protoNumType
+- alloy.proto#protoWrapped
+- alloy.proto#protoCompactUUID
 
 Additionally, the following traits can be taken into consideration by other tooling to translate smithy specifications to proto specifications.
 

--- a/docs/serialisation/json.md
+++ b/docs/serialisation/json.md
@@ -1,8 +1,8 @@
-### JSON serialisation
+## JSON serialisation
 
 `alloy` defines a number of traits that can be taken into consideration by protocols to express additional constraints and encodings typically found in the industry.
 
-#### Unions
+### Unions
 
 Unions in this protocol can be encoded in three different ways: tagged, discriminated, and untagged.
 
@@ -11,7 +11,7 @@ By default, the specification of the Smithy language hints that the `tagged-unio
 However, `alloy#simpleRestJson` supports two additional encodings: `discriminated` and `untagged`, which users can opt-in via the `alloy#discriminated` and `alloy#untagged` trait, respectively. These are mostly offered as a way to retrofit existing APIs in Smithy.
 
 
-##### Tagged union
+#### Tagged union
 
 This is the default behavior, and happens to visually match how Smithy unions are declared. In this encoding, the union is encoded as a JSON object with a single key-value pair, the key signalling which alternative has been encoded.
 

--- a/docs/serialisation/protobuf.md
+++ b/docs/serialisation/protobuf.md
@@ -133,33 +133,12 @@ message Foo {
 
 ### Documents
 
-Documents should be serialised using a protobuf message equivalent to the one below :
+Documents should be serialised using a protobuf message equivalent to the [`google.protobuf.Value`](https://github.com/protocolbuffers/protobuf/blob/5ecfdd76ef25f069cd84fac0b0fb3b95e2d61a34/src/google/protobuf/struct.proto#L62) type, which is commonly used in the protobuf ecosystem to represent [JSON values](https://protobuf.dev/reference/protobuf/google.protobuf/#value).
 
-```proto
-message DNull {
-}
+### Timestamp
 
-message DArray {
-  repeated Document values = 1;
-}
+Documents should be serialised using a protobuf message equivalent to the [`google.protobuf.Timestamp`](https://github.com/protocolbuffers/protobuf/blob/5ecfdd76ef25f069cd84fac0b0fb3b95e2d61a34/src/google/protobuf/timestamp.proto#L133) type, which is commonly used in the protobuf ecosystem to represent [Timestamp values](https://protobuf.dev/reference/protobuf/google.protobuf/#timestamp).
 
-message DObject {
-  map<string, Document> values = 1;
-}
-
-message Document {
-  oneof value {
-    DNull dNull = 1;
-    bool dBoolean = 2;
-    double dNumber = 3;
-    string dString = 4;
-    DArray dArray = 5;
-    DObject dObject = 6;
-  }
-}
-```
-
-For convenience, alloy provides this proto definition in a jar publised to maven-central `alloy-protobuf`
 
 ### Aggregate Types
 

--- a/docs/serialisation/protobuf.md
+++ b/docs/serialisation/protobuf.md
@@ -163,8 +163,10 @@ For convenience, alloy provides this proto definition in a jar publised to maven
 
 ### Aggregate Types
 
-Structure, unions and (string) enumerations follow the rule that unless specified otherwise, the "proto indexes" (or "field numbers") assigned
-to their members should be monotonically increase. The first member receives the index `1` in the case of structures and unions, whilst it receives the index `0` in the case of enumerations.
+In the absence of explicit `@protoIndex` traits on their members, the following rules is applied for structures/unions/string enumerations:
+
+* In the case of structure and union members, the members should be treated as having an implicit protobuf field value starting from 1 for the first member, and increasing monotonically (by 1) for each subsequent member.
+* In the case of string enumerations, the members should be treated as having an implicit protobuf field value string from 0 for the first member, and increasing monotonically (by 1) for each subsequent member.
 
 #### Structures
 

--- a/docs/serialisation/protobuf.md
+++ b/docs/serialisation/protobuf.md
@@ -426,7 +426,7 @@ structure Test {
 }
 ```
 
-has the following meaning in proto semantics
+has the following meaning in protobuf semantics
 
 ```proto
 message Test {

--- a/docs/serialisation/protobuf.md
+++ b/docs/serialisation/protobuf.md
@@ -78,6 +78,38 @@ message Foo {
 }
 ```
 
+#### Document
+
+Documents are translate to recursive messages
+
+Smithy:
+
+```smithy
+structure Foo {
+  document: Document
+}
+```
+
+Proto:
+```proto
+message Empty {}
+
+message Document {
+  oneof value {
+    Empty dNull = 1;
+    boolean dBoolean = 2;
+    double dNumber = 3;
+    string dString = 4;
+    repeated MyDocument dArray = 5;
+    map<string, Document> dObject = 6;
+  }
+}
+
+message Foo {
+  Document document = 1;
+}
+```
+
 #### Aggregate Types
 
 ##### Structure

--- a/docs/serialisation/protobuf.md
+++ b/docs/serialisation/protobuf.md
@@ -442,7 +442,7 @@ When one member is annotated with a `@protoIndex`, all members have to be annota
 
 ##### protoIndex for enumerations
 
-Members of closed enumerations (whether string or int) can be annotated by `alloy.proto#protoIndex` in smithy to customise the corresponding proto index that should be used during serialisation. An additional constraint is that when users elect to specify `alloy.proto#protoIndex`, they are required to assign the `0` value to one of the enumeration members, as it is a requirement on the protobuf side.
+Members of closed enumerations (whether string or int) can be annotated by `alloy.proto#protoIndex` in smithy to customise the corresponding proto index that should be used during serialisation. An additional constraint is that when users elect to specify `alloy.proto#protoIndex`, they are required to assign the `0` value to one of the enumeration members, as it is a requirement for protobuf.
 
 On the other hand, members of open enumerations MUST NOT be annotated with `alloy.proto#protoIndex`, as open enumerations in Smithy translate to the raw string/int in protobuf, allowing for the capture of unknown value regardless of how the target language generates enumerations.
 

--- a/docs/serialisation/protobuf.md
+++ b/docs/serialisation/protobuf.md
@@ -137,7 +137,7 @@ Documents should be serialised using a protobuf message equivalent to the [`goog
 
 ### Timestamp
 
-Documents should be serialised using a protobuf message equivalent to the [`google.protobuf.Timestamp`](https://github.com/protocolbuffers/protobuf/blob/5ecfdd76ef25f069cd84fac0b0fb3b95e2d61a34/src/google/protobuf/timestamp.proto#L133) type, which is commonly used in the protobuf ecosystem to represent [Timestamp values](https://protobuf.dev/reference/protobuf/google.protobuf/#timestamp).
+Timestamps should be serialised using a protobuf message equivalent to the [`google.protobuf.Timestamp`](https://github.com/protocolbuffers/protobuf/blob/5ecfdd76ef25f069cd84fac0b0fb3b95e2d61a34/src/google/protobuf/timestamp.proto#L133) type, which is commonly used in the protobuf ecosystem to represent [Timestamp values](https://protobuf.dev/reference/protobuf/google.protobuf/#timestamp).
 
 
 ### Aggregate Types

--- a/docs/serialisation/protobuf.md
+++ b/docs/serialisation/protobuf.md
@@ -14,7 +14,7 @@ com.disneystreaming.alloy:alloy-protocol:x.y.z
 
 ### Validation
 
-`alloy` comes with validator that verifies the abidance of shapes to the rules described below. Note that these validators are protocol-specific, and
+`alloy` comes with validators that verify the abidance of shapes to the rules described below. Note that these validators are protocol-specific, and
 are only verifying shapes that belong to the transitive closure of shapes annotated with either `alloy.proto#grpc` or `alloy.proto#protoEnabled`.
 
 ### Primitives

--- a/docs/serialisation/protobuf.md
+++ b/docs/serialisation/protobuf.md
@@ -1,4 +1,4 @@
-### Protobuf serialisation
+## Protobuf serialisation
 
 When protocols use protobuf as a serialisation, alloy also proposes a set of semantics for how smithy shapes translate to protobuf-specific concepts. In this document, we describe these semantics by explaining how the smithy code should translate to proto code representing the equivalent data.
 
@@ -12,12 +12,12 @@ Note that for convenience, `alloy` provides a module containing protobuf definit
 com.disneystreaming.alloy:alloy-protocol:x.y.z
 ```
 
-#### Validation
+### Validation
 
 `alloy` comes with validator that verifies the abidance of shapes to the rules described below. Note that these validators are protocol-specific, and
 are only verifying shapes that belong to the transitive closure of shapes annotated with either `alloy.proto#grpc` or `alloy.proto#protoEnabled`.
 
-#### Primitives
+### Primitives
 
 Below is a table describing how smithy shapes translate to proto constructs.
 
@@ -45,7 +45,7 @@ Protobuf supports a number of [scalar types](https://developers.google.com/proto
 | long                 | UNSIGNED      | uint64                                        |
 | timestamp            | N/A           | message { long seconds = 1; long nanos = 2; } |
 
-##### alloy.proto#protoWrapped
+#### alloy.proto#protoWrapped
 
 Additionally, in the context of `alloy`, the presence of the `@protoWrapped` trait is interpreted as requiring the primitive to be wrapped in a one-field message.
 
@@ -87,7 +87,7 @@ Using `protoWrapped` is interesting as it permits the distinction between the ab
 | long                 | SIGNED        | alloy.protobuf.SInt64Value      |
 | long                 | UNSIGNED      | google.protobuf.UInt64Value     |
 
-##### alloy.proto#protoNumType
+#### alloy.proto#protoNumType
 
 Integer and Long shapes can be annotated with the `@alloy.proto#protoNumType` in order to signal what encoding should be used during protobuf serialisation.
 
@@ -131,7 +131,7 @@ message Foo {
 }
 ```
 
-#### Document
+### Documents
 
 Documents should be serialised using a protobuf message equivalent to the one below :
 
@@ -161,12 +161,12 @@ message Document {
 
 For convenience, alloy provides this proto definition in a jar publised to maven-central `alloy-protobuf`
 
-#### Aggregate Types
+### Aggregate Types
 
 Structure, unions and (string) enumerations follow the rule that unless specified otherwise, the "proto indexes" (or "field numbers") assigned
 to their members should be monotonically increase. The first member receives the index `1` in the case of structures and unions, whilst it receives the index `0` in the case of enumerations.
 
-##### Structure
+#### Structures
 
 Smithy:
 ```smithy
@@ -186,7 +186,7 @@ message Testing {
 }
 ```
 
-##### Union
+#### Unions
 
 Unions in Smithy are tricky to translate to Protobuf because of the nature of `oneOf` : unions are first-class citizens in Smithy, whereas `oneOf` can only exist relatively to messages in proto. Therefore, the default encoding for unions in protobuf is equivalent to the one of a proto `message` that contains a `definition` field which is the `oneOf`. For example:
 
@@ -250,6 +250,11 @@ message Union {
   }
 }
 ```
+
+##### Union members targeting collections
+
+Protobuf doesn't allow `oneof` members to have `repeated` or `map` fields. As a result, a smithy union with a members targeting a collection shapes MUST
+either have the `@protoWrapped` trait or target a collection shape have the `@protoWrapped` trait.
 
 ##### Inlined unions (`alloy.proto#protoInlinedOneOf`)
 
@@ -335,7 +340,7 @@ message StringStringMap {
 }
 ```
 
-##### String Enum (closed)
+##### String Enumerations (closed)
 
 Smithy:
 ```smithy
@@ -355,7 +360,7 @@ enum Color {
 }
 ```
 
-##### String Enum (open)
+##### String Enumerations (open)
 
 Open string enumerations are considered as raw strings when serialised to protobuf :
 
@@ -380,7 +385,7 @@ message Foo {
 }
 ```
 
-##### Int Enum (closed)
+##### Integer Enumerations (closed)
 
 Each value translates to the proto index. Because of this, one of the values MUST be 0, as proto enforces each enumeration to have a value set to 0.
 
@@ -402,7 +407,7 @@ enum Color {
 }
 ```
 
-##### Int Enum (open)
+##### Integer Enumerations (open)
 
 Open int enumerations are considered as raw integers when serialised to protobuf :
 

--- a/docs/serialisation/protobuf.md
+++ b/docs/serialisation/protobuf.md
@@ -239,7 +239,7 @@ either have the `@protoWrapped` trait or target a collection shape have the `@pr
 
 ##### Inlined unions (`alloy.proto#protoInlinedOneOf`)
 
-The `alloy.proto#protoInlinedOneOf` trait can be used to inline the corresponding `oneof` in a protobuf message. A union with this trait MUST be used referenced exactly once, by a structure member.
+The `alloy.proto#protoInlinedOneOf` trait can be used to inline the corresponding `oneof` in a protobuf message. A union with this trait MUST be used exactly once, by a structure member.
 
 For example, this is valid:
 

--- a/modules/core/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/modules/core/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -16,6 +16,8 @@ alloy.proto.ProtoIndexTrait$Provider
 alloy.proto.ProtoInlinedOneOfTrait$Provider
 alloy.proto.ProtoNumTypeTrait$Provider
 alloy.proto.ProtoReservedFieldsTrait$Provider
+alloy.proto.ProtoCompactUUIDTrait$Provider
+alloy.proto.ProtoWrappedTrait$Provider
 alloy.SimpleRestJsonTrait$Provider
 alloy.StructurePatternTrait$Provider
 alloy.UrlFormFlattenedTrait$Provider

--- a/modules/core/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/modules/core/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -4,6 +4,7 @@ alloy.proto.validation.ProtoInlinedOneOfValidator
 alloy.proto.validation.ProtoReservedFieldsTraitValidator
 alloy.proto.validation.ProtoIntEnumValidator
 alloy.proto.validation.ProtoUnionMemberValidator
+alloy.proto.validation.ProtoMapKeyValidator
 alloy.validation.DataExamplesTraitValidator
 alloy.validation.DefaultValueTraitValidator
 alloy.validation.DiscriminatedUnionValidator

--- a/modules/core/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/modules/core/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -3,6 +3,7 @@ alloy.proto.validation.ProtoIndexTraitValidator
 alloy.proto.validation.ProtoInlinedOneOfValidator
 alloy.proto.validation.ProtoReservedFieldsTraitValidator
 alloy.proto.validation.ProtoIntEnumValidator
+alloy.proto.validation.ProtoUnionMemberValidator
 alloy.validation.DataExamplesTraitValidator
 alloy.validation.DefaultValueTraitValidator
 alloy.validation.DiscriminatedUnionValidator

--- a/modules/core/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/modules/core/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -2,6 +2,7 @@ alloy.proto.validation.GrpcTraitValidator
 alloy.proto.validation.ProtoIndexTraitValidator
 alloy.proto.validation.ProtoInlinedOneOfValidator
 alloy.proto.validation.ProtoReservedFieldsTraitValidator
+alloy.proto.validation.ProtoIntEnumValidator
 alloy.validation.DataExamplesTraitValidator
 alloy.validation.DefaultValueTraitValidator
 alloy.validation.DiscriminatedUnionValidator

--- a/modules/core/resources/META-INF/smithy/proto/proto.smithy
+++ b/modules/core/resources/META-INF/smithy/proto/proto.smithy
@@ -21,22 +21,12 @@ structure grpc {}
 
 /// Marks an explicit index to be used for a structure member when it is
 /// interpreted as protobuf. For example:
-/// structure Test {
-/// str: String
-/// }
+///
+/// structure Test { @protoIndex(2) str: String }
+///
 /// Is equivalent to:
-/// message Test {
-/// string str = 1;
-/// }
-/// Where the following:
-/// structure Test {
-/// @protoIndex(2)
-/// str: String
-/// }
-/// Is equivalent to:
-/// message Test {
-/// string str = 2;
-/// }
+///
+/// message Test { string str = 2 }
 @trait(selector: ":is(structure > member,union > member,enum > member)")
 integer protoIndex
 
@@ -105,5 +95,7 @@ structure protoWrapped {}
 
 // indicates that string abiding by @alloy#uuidFormat should
 // be encoded using a proto message containing 2 long values.
-@trait(selector: ":test(string [trait|alloy#uuidFormat], member > string [trait|alloy#uuidFormat])")
+@trait(
+    selector: ":test(string [trait|alloy#uuidFormat], member > string [trait|alloy#uuidFormat])"
+)
 structure protoCompactUUID {}

--- a/modules/core/resources/META-INF/smithy/proto/proto.smithy
+++ b/modules/core/resources/META-INF/smithy/proto/proto.smithy
@@ -27,7 +27,9 @@ structure grpc {}
 /// Is equivalent to:
 ///
 /// message Test { string str = 2 }
-@trait(selector: ":is(structure > member,union > member,enum > member)")
+@trait(
+    selector: ":is(structure > member,union > member,enum > member, intEnum > member)"
+)
 integer protoIndex
 
 /// Specifies which type of number signing should be used on integers

--- a/modules/core/resources/META-INF/smithy/proto/proto.smithy
+++ b/modules/core/resources/META-INF/smithy/proto/proto.smithy
@@ -90,7 +90,9 @@ structure protoInlinedOneOf {}
 // This trait can be used to enforce values being wrapped in
 // single-field messages, which allows for distinguishing between
 // absence of values and default values.
-@trait(selector: ":test(simpleType, member > simpleType)")
+@trait(
+    selector: ":test(simpleType, list, map, member > simpleType, member > list, member > map)"
+)
 structure protoWrapped {}
 
 // indicates that string abiding by @alloy#uuidFormat should

--- a/modules/core/resources/META-INF/smithy/proto/proto.smithy
+++ b/modules/core/resources/META-INF/smithy/proto/proto.smithy
@@ -3,35 +3,39 @@ $version: "2"
 namespace alloy.proto
 
 use alloy#uncheckedExamples
-
+use alloy#uuidFormat
 /// GRPC protocol as defined by https://grpc.io/
-@protocolDefinition(traits: [
-    protoReservedFields,
-    protoIndex,
-    protoNumType,
-    protoEnabled,
-    uncheckedExamples
-])
+
+@protocolDefinition(
+    traits: [
+
+        protoReservedFields
+        protoIndex
+        protoNumType
+        protoEnabled
+        uncheckedExamples
+    ]
+)
 @trait(selector: "service")
 structure grpc {}
 
 /// Marks an explicit index to be used for a structure member when it is
 /// interpreted as protobuf. For example:
 /// structure Test {
-///   str: String
+/// str: String
 /// }
 /// Is equivalent to:
 /// message Test {
-///   string str = 1;
+/// string str = 1;
 /// }
 /// Where the following:
 /// structure Test {
-///   @protoIndex(2)
-///   str: String
+/// @protoIndex(2)
+/// str: String
 /// }
 /// Is equivalent to:
 /// message Test {
-///   string str = 2;
+/// string str = 2;
 /// }
 @trait(selector: ":is(structure > member,union > member,enum > member)")
 integer protoIndex
@@ -40,10 +44,10 @@ integer protoIndex
 /// and longs.
 @trait(selector: ":test(integer, long, member > :test(integer, long))")
 enum protoNumType {
-  SIGNED
-  UNSIGNED
-  FIXED
-  FIXED_SIGNED
+    SIGNED
+    UNSIGNED
+    FIXED
+    FIXED_SIGNED
 }
 
 /// Marks certain field indexes as unusable by the smithy
@@ -53,20 +57,20 @@ enum protoNumType {
 /// are inclusive.
 @trait(selector: "structure")
 list protoReservedFields {
-  member: ReservedFieldsDefinition
+    member: ReservedFieldsDefinition
 }
 
 union ReservedFieldsDefinition {
-  name: String
-  number: Integer
-  range: Range
+    name: String
+    number: Integer
+    range: Range
 }
 
 structure Range {
-  @required
-  start: Integer
-  @required
-  end: Integer
+    @required
+    start: Integer
+    @required
+    end: Integer
 }
 
 /// This trait can be used to enable protobuf conversion
@@ -74,7 +78,6 @@ structure Range {
 /// GRPC service.
 @trait(selector: ":test(structure, service)")
 structure protoEnabled {}
-
 
 /// This trait can be used to customize the rendering of an
 /// Union shape during the conversion to Protobuf models.
@@ -93,3 +96,14 @@ structure protoEnabled {}
 /// implement this encoding.
 @trait(selector: "union")
 structure protoInlinedOneOf {}
+
+// This trait can be used to enforce values being wrapped in
+// single-field messages, which allows for distinguishing between
+// absence of values and default values.
+@trait(selector: ":test(simpleType, member > simpleType)")
+structure protoWrapped {}
+
+// indicates that string abiding by @alloy#uuidFormat should
+// be encoded using a proto message containing 2 long values.
+@trait(selector: ":test(string [trait|alloy#uuidFormat], member > string [trait|alloy#uuidFormat])")
+structure protoCompactUUID {}

--- a/modules/core/src/alloy/proto/ProtoCompactUUIDTrait.java
+++ b/modules/core/src/alloy/proto/ProtoCompactUUIDTrait.java
@@ -1,0 +1,46 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.proto;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AnnotationTrait;
+import software.amazon.smithy.model.traits.AbstractTrait;
+
+public class ProtoCompactUUIDTrait extends AnnotationTrait {
+
+	public static ShapeId ID = ShapeId.from("alloy.proto#protoCompactUUID");
+
+	public ProtoCompactUUIDTrait(ObjectNode node) {
+		super(ID, node);
+	}
+
+	public ProtoCompactUUIDTrait() {
+		super(ID, Node.objectNode());
+	}
+
+	public static final class Provider extends AbstractTrait.Provider {
+		public Provider() {
+			super(ID);
+		}
+
+		@Override
+		public GrpcTrait createTrait(ShapeId target, Node node) {
+			return new GrpcTrait(node.expectObjectNode());
+		}
+	}
+}

--- a/modules/core/src/alloy/proto/ProtoCompactUUIDTrait.java
+++ b/modules/core/src/alloy/proto/ProtoCompactUUIDTrait.java
@@ -39,8 +39,8 @@ public class ProtoCompactUUIDTrait extends AnnotationTrait {
 		}
 
 		@Override
-		public GrpcTrait createTrait(ShapeId target, Node node) {
-			return new GrpcTrait(node.expectObjectNode());
+		public ProtoCompactUUIDTrait createTrait(ShapeId target, Node node) {
+			return new ProtoCompactUUIDTrait(node.expectObjectNode());
 		}
 	}
 }

--- a/modules/core/src/alloy/proto/ProtoWrappedTrait.java
+++ b/modules/core/src/alloy/proto/ProtoWrappedTrait.java
@@ -39,8 +39,8 @@ public class ProtoWrappedTrait extends AnnotationTrait {
 		}
 
 		@Override
-		public GrpcTrait createTrait(ShapeId target, Node node) {
-			return new GrpcTrait(node.expectObjectNode());
+		public ProtoWrappedTrait createTrait(ShapeId target, Node node) {
+			return new ProtoWrappedTrait(node.expectObjectNode());
 		}
 	}
 }

--- a/modules/core/src/alloy/proto/ProtoWrappedTrait.java
+++ b/modules/core/src/alloy/proto/ProtoWrappedTrait.java
@@ -1,0 +1,46 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.proto;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AnnotationTrait;
+import software.amazon.smithy.model.traits.AbstractTrait;
+
+public class ProtoWrappedTrait extends AnnotationTrait {
+
+	public static ShapeId ID = ShapeId.from("alloy.proto#protoWrapped");
+
+	public ProtoWrappedTrait(ObjectNode node) {
+		super(ID, node);
+	}
+
+	public ProtoWrappedTrait() {
+		super(ID, Node.objectNode());
+	}
+
+	public static final class Provider extends AbstractTrait.Provider {
+		public Provider() {
+			super(ID);
+		}
+
+		@Override
+		public GrpcTrait createTrait(ShapeId target, Node node) {
+			return new GrpcTrait(node.expectObjectNode());
+		}
+	}
+}

--- a/modules/core/src/alloy/proto/validation/ProtoIndexTraitValidator.java
+++ b/modules/core/src/alloy/proto/validation/ProtoIndexTraitValidator.java
@@ -107,12 +107,12 @@ final public class ProtoIndexTraitValidator extends AbstractValidator {
 			indexCheck = Stream.empty();
 		}
 
-		Stream<ValidationEvent> openStringEnumChecks = null;
+		Stream<ValidationEvent> openEnumChecks = null;
 		if ((shape.isEnumShape() || shape.isIntEnumShape()) && shape.hasTrait(OpenEnumTrait.class)) {
 			if (noFieldIsIndexed) {
-				openStringEnumChecks = Stream.empty();
+				openEnumChecks = Stream.empty();
 			} else {
-				openStringEnumChecks = Stream.of(ValidationEvent.builder().id(OPEN_ENUM_MUST_NOT_HAVE_INDEXES)
+				openEnumChecks = Stream.of(ValidationEvent.builder().id(OPEN_ENUM_MUST_NOT_HAVE_INDEXES)
 						.message("Members of enumeration" + shape + "must not have the `@protoIndex` trait applied.")
 						.shape(shape).severity(Severity.ERROR).build());
 			}
@@ -137,8 +137,7 @@ final public class ProtoIndexTraitValidator extends AbstractValidator {
 			enumHasZeroChecks = Stream.empty();
 		}
 
-		return Stream.of(indexCheck, enumHasZeroChecks, openStringEnumChecks).flatMap(s -> s)
-				.collect(Collectors.toList());
+		return Stream.of(indexCheck, enumHasZeroChecks, openEnumChecks).flatMap(s -> s).collect(Collectors.toList());
 
 	}
 

--- a/modules/core/src/alloy/proto/validation/ProtoIntEnumValidator.java
+++ b/modules/core/src/alloy/proto/validation/ProtoIntEnumValidator.java
@@ -1,0 +1,71 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.proto.validation;
+
+import alloy.proto.ProtoInlinedOneOfTrait;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.IntEnumShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.Severity;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.model.neighbor.NeighborProvider;
+import software.amazon.smithy.model.neighbor.Walker;
+import alloy.OpenEnumTrait;
+import alloy.proto.ProtoEnabledTrait;
+import alloy.proto.ProtoIndexTrait;
+import alloy.proto.GrpcTrait;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class ProtoIntEnumValidator extends AbstractValidator {
+	public final static String PROTO_INT_ENUM_HAS_NO_ZERO = "ProtoIntEnumHasNoZero";
+
+	@Override
+	public List<ValidationEvent> validate(Model model) {
+		Walker walker = new Walker(NeighborProvider.of(model));
+		Set<Shape> protoEnabledShapes = model.getShapesWithTrait(ProtoEnabledTrait.class);
+		Set<Shape> grpcShapes = model.getShapesWithTrait(GrpcTrait.class);
+		return Stream.concat(protoEnabledShapes.stream(), grpcShapes.stream())
+				// this rule applies to protoEnabled-connected shapes
+				.flatMap(shape -> walker.walkShapes(shape).stream()).filter(shape -> shape.isIntEnumShape()) //
+				.map(shape -> (IntEnumShape) shape)
+				// this rule applies to int enums the members of which are not labelled with
+				// @protoIndex
+				.filter(intEnum -> !intEnum.hasTrait(OpenEnumTrait.class)).filter(intEnum -> intEnum.members().stream()
+						.noneMatch(member -> member.hasTrait(ProtoIndexTrait.class)))
+				.flatMap(intEnum -> {
+					Collection<Integer> values = intEnum.getEnumValues().values();
+					if (values.contains(0)) {
+						return Stream.empty();
+					} else {
+						ValidationEvent error = ValidationEvent.builder().id(PROTO_INT_ENUM_HAS_NO_ZERO).shape(intEnum)
+								.severity(Severity.ERROR)
+								.message(
+										"intEnum shape must have a 0 value when connected to a shape that has the protoEnabled trait")
+								.build();
+						return Stream.of(error);
+					}
+				}).collect(Collectors.toList());
+	}
+
+}

--- a/modules/core/src/alloy/proto/validation/ProtoIntEnumValidator.java
+++ b/modules/core/src/alloy/proto/validation/ProtoIntEnumValidator.java
@@ -29,6 +29,7 @@ import alloy.OpenEnumTrait;
 import alloy.proto.ProtoEnabledTrait;
 import alloy.proto.ProtoIndexTrait;
 import alloy.proto.GrpcTrait;
+import alloy.validation.OptionHelper;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -47,8 +48,8 @@ public final class ProtoIntEnumValidator extends AbstractValidator {
 		Set<Shape> grpcShapes = model.getShapesWithTrait(GrpcTrait.class);
 		return Stream.concat(protoEnabledShapes.stream(), grpcShapes.stream())
 				// this rule applies to protoEnabled-connected shapes
-				.flatMap(shape -> walker.walkShapes(shape).stream()).filter(shape -> shape.isIntEnumShape()) //
-				.map(shape -> (IntEnumShape) shape)
+				.flatMap(shape -> walker.walkShapes(shape).stream())
+				.flatMap(shape -> OptionHelper.toStream(shape.asIntEnumShape()))
 				// this rule applies to int enums the members of which are not labelled with
 				// @protoIndex
 				.filter(intEnum -> !intEnum.hasTrait(OpenEnumTrait.class)).filter(intEnum -> intEnum.members().stream()

--- a/modules/core/src/alloy/proto/validation/ProtoMapKeyValidator.java
+++ b/modules/core/src/alloy/proto/validation/ProtoMapKeyValidator.java
@@ -25,6 +25,7 @@ import software.amazon.smithy.model.neighbor.NeighborProvider;
 import software.amazon.smithy.model.neighbor.Walker;
 import alloy.OpenEnumTrait;
 import alloy.proto.*;
+import alloy.validation.OptionHelper;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -43,8 +44,8 @@ public final class ProtoMapKeyValidator extends AbstractValidator {
 		Set<Shape> grpcShapes = model.getShapesWithTrait(GrpcTrait.class);
 		return Stream.concat(protoEnabledShapes.stream(), grpcShapes.stream())
 				// this rule applies to protoEnabled-connected shapes
-				.flatMap(shape -> walker.walkShapes(shape).stream()).filter(shape -> shape.isMapShape())
-				.map(shape -> (MapShape) shape).flatMap(mapShape -> {
+				.flatMap(shape -> walker.walkShapes(shape).stream())
+				.flatMap(shape -> OptionHelper.toStream(shape.asMapShape())).flatMap(mapShape -> {
 					MemberShape key = mapShape.getKey();
 					Shape keyTarget = model.expectShape(key.getTarget());
 					boolean keyHasWrapped = key.hasTrait(ProtoWrappedTrait.class);

--- a/modules/core/src/alloy/proto/validation/ProtoMapKeyValidator.java
+++ b/modules/core/src/alloy/proto/validation/ProtoMapKeyValidator.java
@@ -1,0 +1,65 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.proto.validation;
+
+import alloy.proto.ProtoInlinedOneOfTrait;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.*;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.Severity;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.model.neighbor.NeighborProvider;
+import software.amazon.smithy.model.neighbor.Walker;
+import alloy.OpenEnumTrait;
+import alloy.proto.*;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class ProtoMapKeyValidator extends AbstractValidator {
+	public final static String PROTO_INVALID_MAP_KEY = "PROTO_INVALID_MAP_KEY";
+
+	@Override
+	public List<ValidationEvent> validate(Model model) {
+		Walker walker = new Walker(NeighborProvider.of(model));
+		Set<Shape> protoEnabledShapes = model.getShapesWithTrait(ProtoEnabledTrait.class);
+		Set<Shape> grpcShapes = model.getShapesWithTrait(GrpcTrait.class);
+		return Stream.concat(protoEnabledShapes.stream(), grpcShapes.stream())
+				// this rule applies to protoEnabled-connected shapes
+				.flatMap(shape -> walker.walkShapes(shape).stream()).filter(shape -> shape.isMapShape())
+				.map(shape -> (MapShape) shape).flatMap(mapShape -> {
+					MemberShape key = mapShape.getKey();
+					Shape keyTarget = model.expectShape(key.getTarget());
+					boolean keyHasWrapped = key.hasTrait(ProtoWrappedTrait.class);
+					boolean keyTargetHasWrapped = keyTarget.hasTrait(ProtoWrappedTrait.class);
+					if (keyHasWrapped || keyTargetHasWrapped) {
+						ValidationEvent event = ValidationEvent.builder().id(PROTO_INVALID_MAP_KEY)
+								.severity(Severity.ERROR)
+								.message(
+										"Map keys must not have the alloy.proto#protoWrapped trait, nor target shapes with that trait")
+								.shape(key).build();
+						return Stream.of(event);
+					} else {
+						return Stream.empty();
+					}
+				}).collect(Collectors.toList());
+	}
+
+}

--- a/modules/core/src/alloy/proto/validation/ProtoUnionMemberValidator.java
+++ b/modules/core/src/alloy/proto/validation/ProtoUnionMemberValidator.java
@@ -1,0 +1,65 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.proto.validation;
+
+import alloy.proto.ProtoInlinedOneOfTrait;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.*;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.Severity;
+import software.amazon.smithy.model.validation.ValidationEvent;
+import software.amazon.smithy.model.neighbor.NeighborProvider;
+import software.amazon.smithy.model.neighbor.Walker;
+import alloy.OpenEnumTrait;
+import alloy.proto.*;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class ProtoUnionMemberValidator extends AbstractValidator {
+	public final static String PROTO_UNION_SHAPE_HAS_UNWRAPPED_COLLECTION = "ProtoUnionShapeHasUnwrappedCollection";
+
+	@Override
+	public List<ValidationEvent> validate(Model model) {
+		Walker walker = new Walker(NeighborProvider.of(model));
+		Set<Shape> protoEnabledShapes = model.getShapesWithTrait(ProtoEnabledTrait.class);
+		Set<Shape> grpcShapes = model.getShapesWithTrait(GrpcTrait.class);
+		return Stream.concat(protoEnabledShapes.stream(), grpcShapes.stream())
+				// this rule applies to protoEnabled-connected shapes
+				.flatMap(shape -> walker.walkShapes(shape).stream()).filter(shape -> shape.isUnionShape())
+				.flatMap(unionShape -> unionShape.members().stream()).flatMap(member -> {
+					Shape targetShape = model.expectShape(member.getTarget());
+					boolean memberHasWrapped = member.hasTrait(ProtoWrappedTrait.class);
+					boolean targetHasWrapped = targetShape.hasTrait(ProtoWrappedTrait.class);
+					boolean notWrapped = !memberHasWrapped && !targetHasWrapped;
+					if ((targetShape instanceof MapShape || targetShape instanceof ListShape) && notWrapped) {
+						ValidationEvent event = ValidationEvent.builder().id(PROTO_UNION_SHAPE_HAS_UNWRAPPED_COLLECTION)
+								.severity(Severity.ERROR)
+								.message(
+										"Union members targeting collections must have the alloy.proto#protoWrapped trait")
+								.shape(member).build();
+						return Stream.of(event);
+					} else {
+						return Stream.empty();
+					}
+				}).collect(Collectors.toList());
+	}
+
+}

--- a/modules/core/test/resources/META-INF/smithy/traits.smithy
+++ b/modules/core/test/resources/META-INF/smithy/traits.smithy
@@ -2,6 +2,19 @@ $version: "2"
 
 namespace alloy.test
 
+use alloy#dataExamples
+use alloy#dateFormat
+use alloy#defaultValue
+use alloy#discriminated
+use alloy#nullable
+use alloy#openEnum
+use alloy#simpleRestJson
+use alloy#structurePattern
+use alloy#uncheckedExamples
+use alloy#untagged
+use alloy#urlFormFlattened
+use alloy#urlFormName
+use alloy#uuidFormat
 use alloy.common#countryCodeFormat
 use alloy.common#emailFormat
 use alloy.common#hexColorCodeFormat
@@ -13,34 +26,31 @@ use alloy.proto#protoEnabled
 use alloy.proto#protoIndex
 use alloy.proto#protoInlinedOneOf
 use alloy.proto#protoNumType
+use alloy.proto#protoCompactUUID
+use alloy.proto#protoWrapped
 use alloy.proto#protoReservedFields
-use alloy#dateFormat
-use alloy#defaultValue
-use alloy#discriminated
-use alloy#nullable
-use alloy#openEnum
-use alloy#uncheckedExamples
-use alloy#untagged
-use alloy#uuidFormat
-use alloy#simpleRestJson
-use alloy#dataExamples
-use alloy#structurePattern
-use alloy#urlFormFlattened
-use alloy#urlFormName
 
 @dateFormat
 string MyDate
+
 @emailFormat
-string Email 
+@protoWrapped
+string Email
+
 @countryCodeFormat
 string CountryCode
+
 @languageCodeFormat
 string LanguageCode
+
 @languageTagFormat
 string LanguageTag
+
 @hexColorCodeFormat
 string HexColorCode
+
 @uuidFormat
+@protoCompactUUID
 string ID
 
 structure SomeStruct {
@@ -49,22 +59,21 @@ structure SomeStruct {
     withDef: String
 }
 
-@openapiExtensions(
-  "x-foo": "bar"
-)
+@openapiExtensions("x-foo": "bar")
 list StringList {
     member: String
 }
 
 @discriminated("kind")
 union Thing {
-    a: MyA,
+    a: MyA
     b: MyB
 }
 
 structure MyA {
     value: String
 }
+
 structure MyB {
     value: Integer
 }
@@ -75,7 +84,12 @@ service MyGrpcService {
     operations: [GetAge]
 }
 
-@uncheckedExamples([{title: "dummy", input: { name: "john" }}])
+@uncheckedExamples([{
+    title: "dummy"
+    input: {
+        name: "john"
+    }
+}])
 @http(method: "GET", uri: "/age")
 operation GetAge {
     input := {
@@ -89,7 +103,9 @@ operation GetAge {
 }
 
 @protoEnabled
-@protoReservedFields([{number: 2}])
+@protoReservedFields([{
+    number: 2
+}])
 structure ProtoStruct {
     @protoIndex(1)
     @protoNumType("SIGNED")
@@ -98,7 +114,7 @@ structure ProtoStruct {
 
 @untagged
 union UntaggedUnion {
-    a: Integer,
+    a: Integer
     b: String
 }
 
@@ -115,24 +131,21 @@ structure UnionHost {
 
 @protoInlinedOneOf
 union OtherUnion {
-    a: String,
+    a: String
     b: Integer
 }
 
-@dataExamples([
-    {
-        smithy: {
-            one: "numberOne",
-            two: 2
-        }
-    },
-    {
-        smithy: {
-            one: "numberOneAgain",
-            two: 22
-        }
+@dataExamples([{
+    smithy: {
+        one: "numberOne"
+        two: 2
     }
-])
+}, {
+    smithy: {
+        one: "numberOneAgain"
+        two: 22
+    }
+}])
 structure TestExamples {
     one: String
     two: Integer
@@ -156,10 +169,7 @@ structure TestStringExamples {
     two: Integer
 }
 
-@structurePattern(
-    pattern: "{test}__{test2}"
-    target: TestStructureTarget
-)
+@structurePattern(pattern: "{test}__{test2}", target: TestStructureTarget)
 string TestStructurePattern
 
 structure TestStructureTarget {
@@ -180,7 +190,10 @@ intEnum TestOpenIntEnum {
 }
 
 @openEnum
-@enum([{value: "A", name: "A"}])
+@enum([{
+    value: "A"
+    name: "A"
+}])
 string TestOpenEnumTraitEnum
 
 structure TestUrlFormFlattened {

--- a/modules/core/test/src/alloy/proto/validation/ProtoIndexIntEnumValidatorSuite.scala
+++ b/modules/core/test/src/alloy/proto/validation/ProtoIndexIntEnumValidatorSuite.scala
@@ -1,0 +1,125 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.proto.validation
+
+import munit.FunSuite
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes._
+
+import scala.jdk.CollectionConverters._
+import alloy.proto.ProtoEnabledTrait
+import software.amazon.smithy.model.validation.ValidationEvent
+import software.amazon.smithy.model.validation.Severity
+import alloy.OpenEnumTrait
+import alloy.proto.ProtoIndexTrait
+
+class ProtoIntEnumValidatorSuite extends FunSuite {
+
+  test(
+    "int-enum - no zero leads to errors (when shape is connected to proto-enabled shapes )"
+  ) {
+    val structure = StructureShape
+      .builder()
+      .id("com.example#Struct")
+      .addTrait(new ProtoEnabledTrait())
+      .addMember("foo", ShapeId.from("com.example#Foo"))
+      .build()
+    val foo = IntEnumShape.builder
+      .id("com.example#Foo")
+      .addMember("bar", 1)
+      .build
+    val model = Model.builder
+      .addShapes(structure, foo)
+      .build
+    val events = new ProtoIntEnumValidator()
+      .validate(model)
+      .asScala
+      .toList
+    val event = ValidationEvent
+      .builder()
+      .id(ProtoIntEnumValidator.PROTO_INT_ENUM_HAS_NO_ZERO)
+      .shapeId(foo)
+      .message(
+        "intEnum shape must have a 0 value when connected to a shape that has the protoEnabled trait"
+      )
+      .severity(Severity.ERROR)
+      .build()
+    assertEquals(events, List(event))
+  }
+
+  test("int-enum - no-zero on open enums is valid") {
+    val structure = StructureShape
+      .builder()
+      .id("com.example#Struct")
+      .addTrait(new ProtoEnabledTrait())
+      .addMember("foo", ShapeId.from("com.example#Foo"))
+      .build()
+    val foo = IntEnumShape.builder
+      .id("com.example#Foo")
+      .addMember("bar", 1)
+      .addTrait(new OpenEnumTrait())
+      .build
+    val model = Model.builder
+      .addShapes(structure, foo)
+      .build
+    val events = new ProtoIntEnumValidator()
+      .validate(model)
+      .asScala
+      .toList
+    assertEquals(events, Nil)
+  }
+
+  test(
+    "int-enum - no-zero on open enums is valid if protoIndex(0) is present"
+  ) {
+    val structure = StructureShape
+      .builder()
+      .id("com.example#Struct")
+      .addTrait(new ProtoEnabledTrait())
+      .addMember("foo", ShapeId.from("com.example#Foo"))
+      .build()
+    val foo = IntEnumShape.builder
+      .id("com.example#Foo")
+      .addMember("bar", 1, _.addTrait(new ProtoIndexTrait(0)): Unit)
+      .build
+    val model = Model.builder
+      .addShapes(structure, foo)
+      .build
+    val events = new ProtoIntEnumValidator()
+      .validate(model)
+      .asScala
+      .toList
+    assertEquals(events, Nil)
+  }
+
+  test(
+    "int-enum - no-zero on open enums is valid if shape is not connected to proto-enabled shape"
+  ) {
+    val foo = IntEnumShape.builder
+      .id("com.example#Foo")
+      .addMember("bar", 1)
+      .build
+    val model = Model.builder
+      .addShapes(foo)
+      .build
+    val events = new ProtoIntEnumValidator()
+      .validate(model)
+      .asScala
+      .toList
+    assertEquals(events, Nil)
+  }
+
+}

--- a/modules/core/test/src/alloy/proto/validation/ProtoIntEnumValidatorSuite.scala
+++ b/modules/core/test/src/alloy/proto/validation/ProtoIntEnumValidatorSuite.scala
@@ -83,7 +83,7 @@ class ProtoIntEnumValidatorSuite extends FunSuite {
   }
 
   test(
-    "int-enum - no-zero on open enums is valid if protoIndex(0) is present"
+    "int-enum - no-zero on closed enums is valid if protoIndex(0) is present"
   ) {
     val structure = StructureShape
       .builder()

--- a/modules/core/test/src/alloy/proto/validation/ProtoIntEnumValidatorSuite.scala
+++ b/modules/core/test/src/alloy/proto/validation/ProtoIntEnumValidatorSuite.scala
@@ -29,7 +29,7 @@ import alloy.proto.ProtoIndexTrait
 class ProtoIntEnumValidatorSuite extends FunSuite {
 
   test(
-    "int-enum - no zero leads to errors (when shape is connected to proto-enabled shapes )"
+    "int-enum - no zero leads to errors (when shape is connected to proto-enabled shapes)"
   ) {
     val structure = StructureShape
       .builder()

--- a/modules/core/test/src/alloy/proto/validation/ProtoMapKeyValidatorSuite.scala
+++ b/modules/core/test/src/alloy/proto/validation/ProtoMapKeyValidatorSuite.scala
@@ -1,0 +1,68 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.proto.validation
+
+import munit.FunSuite
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes._
+
+import scala.jdk.CollectionConverters._
+import alloy.proto.ProtoEnabledTrait
+import software.amazon.smithy.model.validation.ValidationEvent
+import software.amazon.smithy.model.validation.Severity
+import alloy.proto.ProtoWrappedTrait
+
+class ProtoMapKeyValidatorSuite extends FunSuite {
+
+  test(
+    "union - non-wrapped collection members are invalid (when shape is connected to proto-enabled shapes)"
+  ) {
+    val string = StringShape.builder().id("com.example#String").build()
+    val structure = StructureShape
+      .builder()
+      .id("com.example#Struct")
+      .addTrait(new ProtoEnabledTrait())
+      .addMember("foo", ShapeId.from("com.example#Map"))
+      .build()
+    val map = MapShape
+      .builder()
+      .id("com.example#Map")
+      .key(
+        string.getId(),
+        _.addTrait(new ProtoWrappedTrait()): Unit
+      )
+      .value(string.getId())
+      .build()
+    val model = Model.builder
+      .addShapes(structure, map, string)
+      .build
+    val events = new ProtoMapKeyValidator()
+      .validate(model)
+      .asScala
+      .toList
+    val mapEvent = ValidationEvent
+      .builder()
+      .id(ProtoMapKeyValidator.PROTO_INVALID_MAP_KEY)
+      .shapeId(ShapeId.from(s"com.example#Map$$key"))
+      .message(
+        "Map keys must not have the alloy.proto#protoWrapped trait, nor target shapes with that trait"
+      )
+      .severity(Severity.ERROR)
+      .build()
+    assertEquals(events, List(mapEvent))
+  }
+
+}

--- a/modules/core/test/src/alloy/proto/validation/ProtoUnionMemberValidatorSuite.scala
+++ b/modules/core/test/src/alloy/proto/validation/ProtoUnionMemberValidatorSuite.scala
@@ -1,0 +1,185 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.proto.validation
+
+import munit.FunSuite
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes._
+
+import scala.jdk.CollectionConverters._
+import alloy.proto.ProtoEnabledTrait
+import software.amazon.smithy.model.validation.ValidationEvent
+import software.amazon.smithy.model.validation.Severity
+import alloy.proto.ProtoWrappedTrait
+
+class ProtoUnionMemberValidatorSuite extends FunSuite {
+
+  test(
+    "union - non-wrapped collection members are invalid (when shape is connected to proto-enabled shapes)"
+  ) {
+    val structure = StructureShape
+      .builder()
+      .id("com.example#Struct")
+      .addTrait(new ProtoEnabledTrait())
+      .addMember("foo", ShapeId.from("com.example#Foo"))
+      .build()
+    val list = ListShape
+      .builder()
+      .id("com.example#List")
+      .member(ShapeId.from("shape.api#String"))
+      .build()
+    val map = MapShape
+      .builder()
+      .id("com.example#Map")
+      .key(ShapeId.from("shape.api#String"))
+      .value(ShapeId.from("shape.api#String"))
+      .build()
+    val foo = UnionShape.builder
+      .id("com.example#Foo")
+      .addMember("list", list.getId())
+      .addMember("map", map.getId())
+      .build
+    val model = Model.builder
+      .addShapes(structure, foo, list, map)
+      .build
+    val events = new ProtoUnionMemberValidator()
+      .validate(model)
+      .asScala
+      .toList
+    val listEvent = ValidationEvent
+      .builder()
+      .id(ProtoUnionMemberValidator.PROTO_UNION_SHAPE_HAS_UNWRAPPED_COLLECTION)
+      .shapeId(ShapeId.from(s"com.example#Foo$$list"))
+      .message(
+        "Union members targeting collections must have the alloy.proto#protoWrapped trait"
+      )
+      .severity(Severity.ERROR)
+      .build()
+    val mapEvent = ValidationEvent
+      .builder()
+      .id(ProtoUnionMemberValidator.PROTO_UNION_SHAPE_HAS_UNWRAPPED_COLLECTION)
+      .shapeId(ShapeId.from(s"com.example#Foo$$map"))
+      .message(
+        "Union members targeting collections must have the alloy.proto#protoWrapped trait"
+      )
+      .severity(Severity.ERROR)
+      .build()
+    assertEquals(events, List(listEvent, mapEvent))
+  }
+
+  // scalafmt: {maxColumn = 120}
+  test(
+    "union - wrapped collection members are valid (when shape is connected to proto-enabled shapes)"
+  ) {
+    val structure = StructureShape
+      .builder()
+      .id("com.example#Struct")
+      .addTrait(new ProtoEnabledTrait())
+      .addMember("foo", ShapeId.from("com.example#Foo"))
+      .build()
+    val list = ListShape
+      .builder()
+      .id("com.example#List")
+      .member(ShapeId.from("shape.api#String"))
+      .build()
+    val map = MapShape
+      .builder()
+      .id("com.example#Map")
+      .key(ShapeId.from("shape.api#String"))
+      .value(ShapeId.from("shape.api#String"))
+      .build()
+    val foo = UnionShape.builder
+      .id("com.example#Foo")
+      .addMember("list", list.getId(), _.addTrait(new ProtoWrappedTrait()): Unit)
+      .addMember("map", map.getId(), _.addTrait(new ProtoWrappedTrait()): Unit)
+      .build
+    val model = Model.builder
+      .addShapes(structure, foo, list, map)
+      .build
+    val events = new ProtoUnionMemberValidator()
+      .validate(model)
+      .asScala
+      .toList
+    assertEquals(events, List())
+  }
+
+  test(
+    "union - members targeting wrapped collections are valid (when shape is connected to proto-enabled shapes)"
+  ) {
+    val structure = StructureShape
+      .builder()
+      .id("com.example#Struct")
+      .addTrait(new ProtoEnabledTrait())
+      .addMember("foo", ShapeId.from("com.example#Foo"))
+      .build()
+    val list = ListShape
+      .builder()
+      .id("com.example#List")
+      .member(ShapeId.from("shape.api#String"))
+      .addTrait(new ProtoWrappedTrait())
+      .build()
+    val map = MapShape
+      .builder()
+      .id("com.example#Map")
+      .key(ShapeId.from("shape.api#String"))
+      .value(ShapeId.from("shape.api#String"))
+      .addTrait(new ProtoWrappedTrait())
+      .build()
+    val foo = UnionShape.builder
+      .id("com.example#Foo")
+      .addMember("list", list.getId())
+      .addMember("map", map.getId())
+      .build
+    val model = Model.builder
+      .addShapes(structure, foo, list, map)
+      .build
+    val events = new ProtoUnionMemberValidator()
+      .validate(model)
+      .asScala
+      .toList
+    assertEquals(events, List())
+  }
+
+  test(
+    "union - members targeting unwrapped collections are valid (unconnected shapes)"
+  ) {
+    val list = ListShape
+      .builder()
+      .id("com.example#List")
+      .member(ShapeId.from("shape.api#String"))
+      .build()
+    val map = MapShape
+      .builder()
+      .id("com.example#Map")
+      .key(ShapeId.from("shape.api#String"))
+      .value(ShapeId.from("shape.api#String"))
+      .build()
+    val foo = UnionShape.builder
+      .id("com.example#Foo")
+      .addMember("list", list.getId())
+      .addMember("map", map.getId())
+      .build
+    val model = Model.builder
+      .addShapes(foo, list, map)
+      .build
+    val events = new ProtoUnionMemberValidator()
+      .validate(model)
+      .asScala
+      .toList
+    assertEquals(events, List())
+  }
+
+}

--- a/modules/core/test/src/alloy/proto/validation/ProtoUnionMemberValidatorSuite.scala
+++ b/modules/core/test/src/alloy/proto/validation/ProtoUnionMemberValidatorSuite.scala
@@ -39,13 +39,13 @@ class ProtoUnionMemberValidatorSuite extends FunSuite {
     val list = ListShape
       .builder()
       .id("com.example#List")
-      .member(ShapeId.from("shape.api#String"))
+      .member(ShapeId.from("smithy.api#String"))
       .build()
     val map = MapShape
       .builder()
       .id("com.example#Map")
-      .key(ShapeId.from("shape.api#String"))
-      .value(ShapeId.from("shape.api#String"))
+      .key(ShapeId.from("smithy.api#String"))
+      .value(ShapeId.from("smithy.api#String"))
       .build()
     val foo = UnionShape.builder
       .id("com.example#Foo")
@@ -93,13 +93,13 @@ class ProtoUnionMemberValidatorSuite extends FunSuite {
     val list = ListShape
       .builder()
       .id("com.example#List")
-      .member(ShapeId.from("shape.api#String"))
+      .member(ShapeId.from("smithy.api#String"))
       .build()
     val map = MapShape
       .builder()
       .id("com.example#Map")
-      .key(ShapeId.from("shape.api#String"))
-      .value(ShapeId.from("shape.api#String"))
+      .key(ShapeId.from("smithy.api#String"))
+      .value(ShapeId.from("smithy.api#String"))
       .build()
     val foo = UnionShape.builder
       .id("com.example#Foo")
@@ -128,14 +128,14 @@ class ProtoUnionMemberValidatorSuite extends FunSuite {
     val list = ListShape
       .builder()
       .id("com.example#List")
-      .member(ShapeId.from("shape.api#String"))
+      .member(ShapeId.from("smithy.api#String"))
       .addTrait(new ProtoWrappedTrait())
       .build()
     val map = MapShape
       .builder()
       .id("com.example#Map")
-      .key(ShapeId.from("shape.api#String"))
-      .value(ShapeId.from("shape.api#String"))
+      .key(ShapeId.from("smithy.api#String"))
+      .value(ShapeId.from("smithy.api#String"))
       .addTrait(new ProtoWrappedTrait())
       .build()
     val foo = UnionShape.builder
@@ -159,13 +159,13 @@ class ProtoUnionMemberValidatorSuite extends FunSuite {
     val list = ListShape
       .builder()
       .id("com.example#List")
-      .member(ShapeId.from("shape.api#String"))
+      .member(ShapeId.from("smithy.api#String"))
       .build()
     val map = MapShape
       .builder()
       .id("com.example#Map")
-      .key(ShapeId.from("shape.api#String"))
-      .value(ShapeId.from("shape.api#String"))
+      .key(ShapeId.from("smithy.api#String"))
+      .value(ShapeId.from("smithy.api#String"))
       .build()
     val foo = UnionShape.builder
       .id("com.example#Foo")

--- a/modules/protobuf/resources/alloy/protobuf/types.proto
+++ b/modules/protobuf/resources/alloy/protobuf/types.proto
@@ -6,30 +6,3 @@ message CompactUUID {
   int64 upper_bits = 1;
   int64 lower_bits = 2;
 }
-
-message Timestamp {
-  int64 seconds = 1;
-  int64 nanos = 2;
-}
-
-message DNull {
-}
-
-message DArray {
-  repeated Document values = 1;
-}
-
-message DObject {
-  map<string, Document> values = 1;
-}
-
-message Document {
-  oneof value {
-    DNull dNull = 1;
-    bool dBoolean = 2;
-    double dNumber = 3;
-    string dString = 4;
-    DArray dArray = 5;
-    DObject dObject = 6;
-  }
-}

--- a/modules/protobuf/resources/alloy/protobuf/types.proto
+++ b/modules/protobuf/resources/alloy/protobuf/types.proto
@@ -1,0 +1,35 @@
+syntax = "proto3";
+
+package alloy.protobuf;
+
+message CompactUUID {
+  int64 upper_bits = 1;
+  int64 lower_bits = 2;
+}
+
+message Timestamp {
+  int64 seconds = 1;
+  int64 nanos = 2;
+}
+
+message DNull {
+}
+
+message DArray {
+  repeated Document values = 1;
+}
+
+message DObject {
+  map<string, Document> values = 1;
+}
+
+message Document {
+  oneof value {
+    DNull dNull = 1;
+    bool dBoolean = 2;
+    double dNumber = 3;
+    string dString = 4;
+    DArray dArray = 5;
+    DObject dObject = 6;
+  }
+}

--- a/modules/protobuf/resources/alloy/protobuf/wrappers.proto
+++ b/modules/protobuf/resources/alloy/protobuf/wrappers.proto
@@ -1,0 +1,57 @@
+syntax = "proto3";
+
+package alloy.protobuf;
+
+import "alloy/protobuf/types.proto";
+
+message TimestampValue {
+  alloy.protobuf.Timestamp value = 1;
+}
+
+message DocumentValue {
+  alloy.protobuf.Document value = 1;
+}
+
+message CompactUUIDValue {
+  alloy.protobuf.CompactUUID value = 1;
+}
+
+message BigIntegerValue {
+  string value = 1;
+}
+
+message BigDecimalValue {
+  string value = 1;
+}
+
+message ByteValue {
+  int32 value = 1;
+}
+
+message ShortValue {
+  int32 value = 1;
+}
+
+message Fixed32Value {
+  fixed32 value = 1;
+}
+
+message Fixed64Value {
+  fixed64 value = 1;
+}
+
+message SFixed32Value {
+  sfixed32 value = 1;
+}
+
+message SFixed64Value {
+  sfixed64 value = 1;
+}
+
+message SInt32Value {
+  sint32 value = 1;
+}
+
+message SInt64Value {
+  sint64 value = 1;
+}

--- a/modules/protobuf/resources/alloy/protobuf/wrappers.proto
+++ b/modules/protobuf/resources/alloy/protobuf/wrappers.proto
@@ -2,14 +2,17 @@ syntax = "proto3";
 
 package alloy.protobuf;
 
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
 import "alloy/protobuf/types.proto";
 
 message TimestampValue {
-  alloy.protobuf.Timestamp value = 1;
+  google.protobuf.Timestamp value = 1;
 }
 
 message DocumentValue {
-  alloy.protobuf.Document value = 1;
+  google.protobuf.Value value = 1;
 }
 
 message CompactUUIDValue {

--- a/smithy-build.json
+++ b/smithy-build.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.0",
   "imports": ["modules/core/resources", "modules/protocol-tests/resources"],
   "maven": {
     "dependencies": [


### PR DESCRIPTION
Rework the protobuf specification. 

The goal is to allow for more control over what should be wrapped in messages and what should not be wrapped, avoiding implicit rules that prevent sound refactoring/evolutions of smithy specifications. 

In particular : 

1. addition of a `alloy.proto#protoWrapped` trait that can be added on simple shapes + lists + maps + members targeting those. This is the only signal allowed for deciding whether something should be wrapped or not. 
2. addition of a number of validation rules for smithy shapes that belong to a transitive closure of a `gRPC` or `protoEnabled shape`. These rules ported from the proto language, such as (but not limited to) : 
   * proto oneof members cannot be repeated/map fields => smithy members of unions targeting map/list shapes MUST have `@protoWrapped`
   * proto maps cannot have messages => smithy map keys MUST NOT have `@protoWrapped`
   * when @protoIndex are present on enum/int enum members, one of the value MUST BE 0
   * when @protoIndex is absent on intEnum members, one of its enum values must be 0 
   * etc etc 
3. created an `alloy-protobuf` artifact with proto files containing messages that can be used by smithy-translate and other tools to facilitate the abidance to the rules described in the alloy protobuf specification 
 
This PR is to remain a draft until the semantics described in it are incorporated in smithy-translate and validated in some "smithy4s-protobuf" POC 