### PR TITLE
Add extra documentation for nullable

### DIFF
--- a/docs/protocols/SimpleRestJson.md
+++ b/docs/protocols/SimpleRestJson.md
@@ -22,6 +22,7 @@ The `alloy#simpleRestJson` protocol is a REST protocol in which all HTTP bodies 
 - alloy#uuidFormat
 - alloy#discriminated
 - alloy#untagged
+- alloy#nullable
 
 #### Protocol Behavior and Semantics
 
@@ -120,3 +121,4 @@ Furthermore, implementors of the protocol have to take into consideration additi
 - `alloy#untagged`
 - `alloy#discriminated`
 - `alloy#uuidFormat`
+- `alloy#nullable`

--- a/docs/serialisation/json.md
+++ b/docs/serialisation/json.md
@@ -113,7 +113,7 @@ are encoded as such
 
 ### Null values
 
-By default, in Smithy a field having a value of `null` and the field being absent are not distinguished. However, this is not required by JSON semantics and APIs can treat the two differently. In order to support this, the additional trait `alloy.nullable` is provided. Annotating the member of a structure field with this indicates that explicit nulls should be preserved on both serialization and deserialization.
+The standard Smithy toolset does not provide any semantics for distinguishing between a JSON field being set to `null` and the same field being absent from its carrying JSON object. However, depending on the use-case, the difference can be meaningful. In order to support such use-cases, the additional trait `alloy.nullable` is provided. Annotating the member of a structure field with this indicates that a value serialised to `null` was a conscious decision (as opposed to omitting the value altogether), and that deserialisation should retain this information.
 
 For example, assuming the following smithy structure
 

--- a/docs/serialisation/json.md
+++ b/docs/serialisation/json.md
@@ -135,7 +135,7 @@ The JSON objects
 {}
 ```
 
-are respectively decoded as
+are respectively decoded as follows in Scala (when using [smithy4s](https://disneystreaming.github.io/smithy4s/)):  
 
 ```scala
 Foo(Some(Nullable.Null), None)

--- a/docs/serialisation/json.md
+++ b/docs/serialisation/json.md
@@ -110,3 +110,45 @@ are encoded as such
 { "tpe": "first", "myString": "alloy" }
 { "tpe": "second", "myInt": 42 }
 ```
+
+### Null values
+
+By default, in Smithy a field having a value of `null` and the field being absent are not distinguished. However, this is not required by JSON semantics and APIs can treat the two differently. In order to support this, the additional trait `alloy.nullable` is provided. Annotating the member of a structure field with this indicates that explicit nulls should be preserved on both serialization and deserialization.
+
+For example, assuming the following smithy structure
+
+```smithy
+use alloy#nullable
+
+structure Foo {
+  @nullable
+  nullable: Integer
+  regular: Integer
+}
+```
+
+The JSON objects
+
+```json
+{ "nullable": null, "regular": null }
+{ "nullable": 4, "regular": 4 }
+{}
+```
+
+are respectively decoded as
+
+```scala
+Foo(Some(Nullable.Null), None)
+Foo(Some(Nullable.Value(4)), Some(4))
+Foo(None, None)
+```
+
+or some similar type which preserves the information that an explicit `null` was passed. These objects are in turn encoded as
+
+```json
+{ "nullable": null }
+{ "nullable": 4, "regular": 4 }
+{}
+```
+
+This means that `@nullable` allows round-tripping null values.


### PR DESCRIPTION
With smithy4s hopefully soon to support the @nullable trait in codegen and JSON codecs ( https://github.com/disneystreaming/smithy4s/pull/1408 ), we add extra documentation indicating that it is a trait which @simpleRestJson supports and the expected behaviour when it comes to serialization.