### PR TITLE
add namespace suppression for UnreferencedShapes

### DIFF
--- a/modules/core/resources/META-INF/smithy/manifest
+++ b/modules/core/resources/META-INF/smithy/manifest
@@ -11,3 +11,4 @@ string.smithy
 unions.smithy
 urlform.smithy
 uuid.smithy
+metadata.smithy

--- a/modules/core/resources/META-INF/smithy/metadata.smithy
+++ b/modules/core/resources/META-INF/smithy/metadata.smithy
@@ -1,0 +1,7 @@
+metadata suppressions = [
+    {
+        id: "UnreferencedShape"
+        namespace: "alloy"
+        reason: "This is a library namespace."
+    }
+]


### PR DESCRIPTION
In order to suppress unreferenced alloy  shapes. Sometimes we describe models that don't  happen to use alloy shapes while others do. Does it make sense to add this here? 