### PR TITLE
fix issue with openapi error response examples

### DIFF
--- a/modules/openapi/src/software/amazon/smithy/openapi/fromsmithy/protocols/AlloyAbstractRestProtocol.scala
+++ b/modules/openapi/src/software/amazon/smithy/openapi/fromsmithy/protocols/AlloyAbstractRestProtocol.scala
@@ -459,9 +459,7 @@ abstract class AlloyAbstractRestProtocol[T <: Trait]
         .addTrait(exTrait)
         .build()
 
-    if (allRelevantExamples.nonEmpty)
-      newShape
-    else operationOrError
+    newShape
   }
 
   private def updateResponsesMapWithResponseStatusAndObject(

--- a/modules/openapi/src/software/amazon/smithy/openapi/fromsmithy/protocols/ExampleNode.scala
+++ b/modules/openapi/src/software/amazon/smithy/openapi/fromsmithy/protocols/ExampleNode.scala
@@ -69,9 +69,11 @@ object ExampleNode {
       memberNames: List[String]
   ): ExampleNode = {
     val members: List[(String, Node)] = memberNames.flatMap(name =>
-      example.getOutput.asScala.flatMap(
-        _.getMember(name).asScala.map(name -> _)
-      )
+      example.getOutput.asScala
+        .orElse(example.getError.asScala.map(_.getContent))
+        .flatMap(
+          _.getMember(name).asScala.map(name -> _)
+        )
     )
     ExampleNode(example, members)
   }

--- a/modules/openapi/test/resources/foo.json
+++ b/modules/openapi/test/resources/foo.json
@@ -129,6 +129,79 @@
         }
       }
     },
+    "/test_errors": {
+      "post": {
+        "operationId": "TestErrorsInExamples",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestErrorsInExamplesRequestContent"
+              },
+              "examples": {
+                "ONE": {
+                  "value": {
+                    "in": "testinput"
+                  }
+                },
+                "TWO": {
+                  "value": {
+                    "in": "testinputtwo"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "TestErrorsInExamples200response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestErrorsInExamplesResponseContent"
+                },
+                "examples": {
+                  "ONE": {
+                    "value": {
+                      "out": "testoutput"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound404response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponseContent"
+                },
+                "examples": {
+                  "TWO": {
+                    "value": {
+                      "message": "Notfoundmessage"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "GeneralServerError500response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralServerErrorResponseContent"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/values": {
       "get": {
         "operationId": "GetValues",
@@ -340,6 +413,17 @@
           }
         ]
       },
+      "NotFoundResponseContent": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
       "SomeValue": {
         "oneOf": [
           {
@@ -351,6 +435,28 @@
             "title": "value",
             "format": "int32"
           }
+        ]
+      },
+      "TestErrorsInExamplesRequestContent": {
+        "type": "object",
+        "properties": {
+          "in": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "in"
+        ]
+      },
+      "TestErrorsInExamplesResponseContent": {
+        "type": "object",
+        "properties": {
+          "out": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "out"
         ]
       }
     }

--- a/modules/openapi/test/resources/foo.smithy
+++ b/modules/openapi/test/resources/foo.smithy
@@ -39,26 +39,26 @@ structure NotFound {
 
 @examples([
   {
-      title: "ONE"
-      input: {
-          in: "test input"
-      }
-      output: {
-          out: "test output"
-      }
+    title: "ONE"
+    input: {
+        in: "test input"
+    }
+    output: {
+        out: "test output"
+    }
   }
   {
-        title: "TWO"
-        input: {
-            in: "test input two"
-        }
-        error: {
-            shapeId: NotFound
-            content: {
-                message: "Not found message"
-            }
+    title: "TWO"
+    input: {
+        in: "test input two"
+    }
+    error: {
+        shapeId: NotFound
+        content: {
+            message: "Not found message"
         }
     }
+  }
 ])
 @http(method: "POST", uri: "/test_errors")
 operation TestErrorsInExamples {

--- a/modules/openapi/test/resources/foo.smithy
+++ b/modules/openapi/test/resources/foo.smithy
@@ -1,3 +1,5 @@
+$version: "2"
+
 namespace foo
 
 use alloy#simpleRestJson
@@ -14,7 +16,7 @@ use alloy#dataExamples
 service HelloWorldService {
   version: "0.0.1",
   errors: [GeneralServerError],
-  operations: [Greet, GetUnion, GetValues]
+  operations: [Greet, GetUnion, GetValues, TestErrorsInExamples]
 }
 
 @externalDocumentation(
@@ -26,6 +28,49 @@ service HelloWorldService {
 operation Greet {
   input: Person,
   output: Greeting
+}
+
+@error("client")
+@httpError(404)
+structure NotFound {
+  @required
+  message: String
+}
+
+@examples([
+  {
+      title: "ONE"
+      input: {
+          in: "test input"
+      }
+      output: {
+          out: "test output"
+      }
+  }
+  {
+        title: "TWO"
+        input: {
+            in: "test input two"
+        }
+        error: {
+            shapeId: NotFound
+            content: {
+                message: "Not found message"
+            }
+        }
+    }
+])
+@http(method: "POST", uri: "/test_errors")
+operation TestErrorsInExamples {
+  input := {
+    @required
+    in: String
+  }
+  output := {
+    @required
+    out: String
+  }
+  errors: [NotFound]
 }
 
 @readonly


### PR DESCRIPTION
Fixes an issue where openapi conversion would put all examples (including error cases) on the `200` response. This updates so that the error cases are instead grouped with the correct status codes.