### PR TITLE
Allow using JSON transformations in OpenAPI Config

### DIFF
--- a/modules/openapi/src/alloy/openapi/package.scala
+++ b/modules/openapi/src/alloy/openapi/package.scala
@@ -81,8 +81,9 @@ package object openapi {
         config.setService(serviceId)
         config.setProtocol(protocol)
         config.setIgnoreUnsupportedTraits(true)
-        val openapi = OpenApiConverter.create().config(config).convert(model)
-        val jsonString = Node.prettyPrintJson(openapi.toNode())
+        val openapi =
+          OpenApiConverter.create().config(config).convertToNode(model)
+        val jsonString = Node.prettyPrintJson(openapi)
         OpenApiConversionResult(protocol, serviceId, jsonString)
       }
     }

--- a/modules/openapi/test/resources/baz.json
+++ b/modules/openapi/test/resources/baz.json
@@ -3,6 +3,5 @@
   "info": {
     "title": "TestService",
     "version": "1"
-  },
-  "components": {}
+  }
 }


### PR DESCRIPTION
Smithy has two methods for converting a model to an OpenAPI object. The one currently being used will only apply a subset of the OpenAPI Config transformations: in particular, it will not apply any transformations that could result in an invalid OpenAPI JSON, such as JsonAdd or any substitutions. This behaviour is surprising as it means valid JSON transformations of the OpenAPI specified in config are also silently ignored. As we do not need the OpenAPI object _as_ OpenAPI but only to render it as JSON, we can use the converter's convertToNode method, which applies all changes specified in the config.