### PR TITLE
fix issue with discriminated transform

### DIFF
--- a/modules/openapi/test/resources/bar.smithy
+++ b/modules/openapi/test/resources/bar.smithy
@@ -20,3 +20,10 @@ union CatOrDog {
     one: String
     two: Integer
 }
+
+structure ProblemSomething {}
+
+@alloy#discriminated("type")
+union Problem {
+    something: ProblemSomething
+}

--- a/modules/openapi/test/src/alloy/openapi/OpenApiConversionSpec.scala
+++ b/modules/openapi/test/src/alloy/openapi/OpenApiConversionSpec.scala
@@ -72,6 +72,30 @@ final class OpenApiConversionSpec extends munit.FunSuite {
     assertEquals(result, expected)
   }
 
+  test(
+    "OpenAPI conversion with one namespace excluded and one included"
+  ) {
+    val model = Model
+      .assembler()
+      .addImport(getClass().getClassLoader().getResource("baz.smithy"))
+      .addImport(getClass().getClassLoader().getResource("bar.smithy"))
+      .discoverModels()
+      .assemble()
+      .unwrap()
+
+    val result = convert(model, Some(Set("baz")))
+      .map(_.contents)
+      .mkString
+      .filterNot(_.isWhitespace)
+
+    val expected = Using
+      .resource(Source.fromResource("baz.json"))(
+        _.getLines().mkString.filterNot(_.isWhitespace)
+      )
+
+    assertEquals(result, expected)
+  }
+
   test("OpenAPI conversion from testJson protocol") {
     val model = Model
       .assembler()


### PR DESCRIPTION
The issue is shown in the test case, but essentially the discriminated union transform was creating some synthetic shapes even when they weren't relevant due to being from the wrong namespace.