### PR TITLE
update openapi/jsonschema conversion to translate jsonUnknown to additionalProperties

### DIFF
--- a/modules/openapi/src/alloy/openapi/AlloyOpenApiExtension.scala
+++ b/modules/openapi/src/alloy/openapi/AlloyOpenApiExtension.scala
@@ -50,7 +50,8 @@ final class AlloyOpenApiExtension() extends Smithy2OpenApiExtension {
     new DataExamplesMapper(),
     new ExternalDocumentationMapperJsonSchema(),
     new NullableMapper(),
-    new DiscriminatedUnionShapeId()
+    new DiscriminatedUnionShapeId(),
+    new JsonUnknownMapper()
   ).asJava
 
 }

--- a/modules/openapi/src/alloy/openapi/JsonUnknownMapper.scala
+++ b/modules/openapi/src/alloy/openapi/JsonUnknownMapper.scala
@@ -1,0 +1,50 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.openapi
+
+import software.amazon.smithy.jsonschema.JsonSchemaMapper
+import software.amazon.smithy.jsonschema.JsonSchemaConfig
+import software.amazon.smithy.jsonschema.Schema.Builder
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.shapes.Shape
+import alloy.JsonUnknownTrait
+
+import scala.jdk.CollectionConverters._
+
+class JsonUnknownMapper() extends JsonSchemaMapper {
+  private final val ADDITIONAL_PROPERTIES = "additionalProperties"
+
+  override def updateSchema(
+      shape: Shape,
+      schemaBuilder: Builder,
+      config: JsonSchemaConfig
+  ): Builder = {
+    val jsonUnknownMemberName = shape
+      .getAllMembers()
+      .asScala
+      .collect {
+        case (name, member) if member.hasTrait(classOf[JsonUnknownTrait]) =>
+          name
+      }
+      .headOption
+
+    jsonUnknownMemberName.fold(schemaBuilder) { name =>
+      schemaBuilder
+        .removeProperty(name)
+        .putExtension(ADDITIONAL_PROPERTIES, Node.from(true))
+    }
+  }
+}

--- a/modules/openapi/test/resources/foo.json
+++ b/modules/openapi/test/resources/foo.json
@@ -305,6 +305,7 @@
             "type": "string"
           }
         },
+        "additionalProperties": true,
         "example": {
           "name": "Woof"
         }

--- a/modules/openapi/test/resources/foo.smithy
+++ b/modules/openapi/test/resources/foo.smithy
@@ -7,6 +7,7 @@ use alloy#discriminated
 use alloy#nullable
 use alloy#untagged
 use alloy#dataExamples
+use alloy#jsonUnknown
 
 @simpleRestJson
 @externalDocumentation(
@@ -164,6 +165,13 @@ structure Cat {
 structure Dog {
   name: String,
   breed: String
+  @jsonUnknown
+  attributes: Attributes
+}
+
+map Attributes {
+  key: String
+  value: Document
 }
 
 @dataExamples([{


### PR DESCRIPTION
Given the following smithy definition

```smithy
structure Dog {
  name: String
  @jsonUnknown
  attributes: Attributes
}

map Attributes {
  key: String
  value: Document
}
```
the following JSON schema will be produced

```json
"Dog": {
  "type": "object",
  "properties": {
    "name": {
      "type": "string"
    }
  },
  "additionalProperties": true
}
```