### PR TITLE
Open unions

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -65,7 +65,11 @@ trait BaseMunitTests extends TestModule.Munit {
 trait BasePublishModule extends BaseModule with CiReleaseModule {
 
   override def publishVersion: T[String] = T {
-    if (isCI()) super.publishVersion() else "dev-SNAPSHOT"
+    if (isCI()) super.publishVersion()
+    else
+      // "dev-SNAPSHOT"
+      // todo
+      "0.13.17-SNAPSHOT"
   }
 
   def isCI = T.input(T.ctx().env.contains("CI"))

--- a/build.sc
+++ b/build.sc
@@ -187,7 +187,10 @@ trait OpenapiModule extends BaseCrossScalaModule {
     Deps.cats.core
   )
 
-  object test extends ScalaTests with BaseMunitTests
+  object test extends ScalaTests with BaseMunitTests {
+    override def ivyDeps: Target[Agg[Dep]] =
+      super.ivyDeps() ++ Seq(Deps.oslib)
+  }
 
   override def mimaBinaryIssueFilters = super.mimaBinaryIssueFilters() ++ Seq(
     ProblemFilter.exclude[MissingClassProblem](
@@ -241,4 +244,6 @@ object Deps {
     val scalaCheck = ivy"org.scalameta::munit-scalacheck::1.1.0"
     val all = Agg(munit, scalaCheck)
   }
+
+  val oslib = ivy"com.lihaoyi::os-lib:0.11.4"
 }

--- a/build.sc
+++ b/build.sc
@@ -65,8 +65,7 @@ trait BaseMunitTests extends TestModule.Munit {
 trait BasePublishModule extends BaseModule with CiReleaseModule {
 
   override def publishVersion: T[String] = T {
-    if (isCI()) super.publishVersion()
-    else "dev-SNAPSHOT"
+    if (isCI()) super.publishVersion() else "dev-SNAPSHOT"
   }
 
   def isCI = T.input(T.ctx().env.contains("CI"))

--- a/build.sc
+++ b/build.sc
@@ -66,10 +66,7 @@ trait BasePublishModule extends BaseModule with CiReleaseModule {
 
   override def publishVersion: T[String] = T {
     if (isCI()) super.publishVersion()
-    else
-      // "dev-SNAPSHOT"
-      // todo
-      "0.13.17-SNAPSHOT"
+    else "dev-SNAPSHOT"
   }
 
   def isCI = T.input(T.ctx().env.contains("CI"))

--- a/modules/core/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
+++ b/modules/core/resources/META-INF/services/software.amazon.smithy.model.validation.Validator
@@ -11,3 +11,4 @@ alloy.validation.DiscriminatedUnionValidator
 alloy.validation.SimpleRestJsonHttpHeaderValidator
 alloy.validation.SimpleRestJsonValidator
 alloy.validation.StructurePatternTraitValidator
+alloy.validation.JsonUnknownTraitValidator

--- a/modules/core/resources/META-INF/smithy/jsonunknown.smithy
+++ b/modules/core/resources/META-INF/smithy/jsonunknown.smithy
@@ -14,5 +14,6 @@ namespace alloy
         )
     "
     structurallyExclusive: "member"
+    conflicts: [jsonName]
 )
 structure jsonUnknown {}

--- a/modules/core/resources/META-INF/smithy/jsonunknown.smithy
+++ b/modules/core/resources/META-INF/smithy/jsonunknown.smithy
@@ -2,7 +2,10 @@ $version: "2"
 
 namespace alloy
 
-/// Retain unknown fields of a containing structure in this map member
+/// Retain unknown fields of a containing structure in this member.
+/// In case of unions, retain unknown cases in this member (open unions).
+/// For both discriminated and tagged unions, this retains the entire object.
+/// For untagged unions, having a Document member has the same effect.
 @trait(
     // selector explanation:
     // struct members that target a map with a `value` member targetting a document, and
@@ -10,7 +13,7 @@ namespace alloy
     selector: "
         :is(
             structure > member :test(> map > member[id|member=value] > document),
-            union > member :test(> document)
+            union:not([trait|alloy#untagged]) > member :test(> document)
         )
     "
     structurallyExclusive: "member"

--- a/modules/core/resources/META-INF/smithy/jsonunknown.smithy
+++ b/modules/core/resources/META-INF/smithy/jsonunknown.smithy
@@ -4,7 +4,15 @@ namespace alloy
 
 /// Retain unknown fields of a containing structure in this map member
 @trait(
-    selector: "structure > member :test(> map > member > document)"
+    // selector explanation:
+    // struct members that target a map with a `value` member targetting a document, and
+    // union members that target a document
+    selector: "
+        :is(
+            structure > member :test(> map > member[id|member=value] > document),
+            union > member :test(> document)
+        )
+    "
     structurallyExclusive: "member"
 )
 structure jsonUnknown {}

--- a/modules/core/resources/META-INF/smithy/unions.smithy
+++ b/modules/core/resources/META-INF/smithy/unions.smithy
@@ -13,7 +13,7 @@ namespace alloy
 /// }
 /// union Test {
 ///   one: One
-///   two: Two  
+///   two: Two
 /// }
 /// would normally be encoded in JSON as:
 /// { "one": { "a": 123 } }
@@ -24,7 +24,10 @@ namespace alloy
 /// but less efficient than using the default tagged union
 /// encoding. Therefore, it should only be used when necessary.
 /// Tagged union encodings should be used wherever possible.
-@trait(selector: "union :not([trait|alloy#untagged])")
+@trait(
+    selector: "union"
+    conflicts: [untagged]
+)
 string discriminated
 
 /// Implies a different encoding for unions where
@@ -41,7 +44,7 @@ string discriminated
 /// }
 /// union Test {
 ///   one: One
-///   two: Two  
+///   two: Two
 /// }
 /// would normally be encoded in JSON as
 /// { "one": { "a": 123 } }
@@ -50,5 +53,8 @@ string discriminated
 /// { "a": 123 }. Therefore the parser will need to try
 /// each different alternative in the union before it can
 /// determine which one is appropriate.
-@trait(selector: "union :not([trait|alloy#discriminated])")
+@trait(
+    selector: "union"
+    conflicts: [discriminated]
+)
 structure untagged {}

--- a/modules/core/src/alloy/validation/DiscriminatedUnionValidator.java
+++ b/modules/core/src/alloy/validation/DiscriminatedUnionValidator.java
@@ -21,6 +21,7 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
 import alloy.DiscriminatedUnionTrait;
+import alloy.JsonUnknownTrait;
 
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,9 @@ public final class DiscriminatedUnionValidator extends AbstractValidator {
 					} else {
 						return Stream.empty();
 					}
+				} else if(entry.getValue().hasTrait(JsonUnknownTrait.ID)) {
+					// @jsonUnknown is an exception to "only structs"
+					return Stream.empty();
 				} else {
 					return Stream.of(error(entry.getValue(),
 							String.format("Target of member '%s' is not a structure shape", entry.getKey())));

--- a/modules/core/src/alloy/validation/JsonUnknownTraitValidator.java
+++ b/modules/core/src/alloy/validation/JsonUnknownTraitValidator.java
@@ -1,0 +1,44 @@
+package alloy.validation;
+
+import alloy.JsonUnknownTrait;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.validation.AbstractValidator;
+import software.amazon.smithy.model.validation.ValidationEvent;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class JsonUnknownTraitValidator extends AbstractValidator {
+    public final static ShapeId ID = ShapeId.from("alloy#jsonUnknown");
+
+    @Override
+    public List<ValidationEvent> validate(Model model) {
+        return model.getMemberShapesWithTrait(JsonUnknownTrait.class)
+                .stream().map(member -> model.expectShape(member.getId().withoutMember()))
+                .filter(Shape::isUnionShape)
+                .distinct()
+                .map(s -> s.asUnionShape().orElseThrow(() -> new IllegalStateException("Expected union shape.")))
+                .flatMap(this::validateUnionShape).collect(Collectors.toList());
+    }
+
+    private Stream<? extends ValidationEvent> validateUnionShape(UnionShape unionShape) {
+        return validateTraitExclusivity(unionShape);
+    }
+
+    /*
+     * Ensures the container only has one member with the trait
+     * */
+    private Stream<ValidationEvent> validateTraitExclusivity(UnionShape unionShape) {
+        List<MemberShape> membersWithTrait = unionShape.members().stream().filter(member -> member.hasTrait(ID)).collect(Collectors.toList());
+
+        if (membersWithTrait.size() > 1) return Stream.of(
+                error(membersWithTrait.get(0), String.format("%s trait was used multiple times within the same union, this is not allowed.", ID), "ConflictingUnionMember")
+        );
+        else return Stream.empty();
+    }
+}

--- a/modules/core/src/alloy/validation/JsonUnknownTraitValidator.java
+++ b/modules/core/src/alloy/validation/JsonUnknownTraitValidator.java
@@ -1,3 +1,18 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package alloy.validation;
 
 import alloy.JsonUnknownTrait;

--- a/modules/core/test/src/alloy/JsonUnknownTraitProviderSpec.scala
+++ b/modules/core/test/src/alloy/JsonUnknownTraitProviderSpec.scala
@@ -242,4 +242,42 @@ final class JsonUnknownTraitProviderSpec extends munit.FunSuite {
       s"validation events should contain one with ID: TraitTarget. Found: $eventIds"
     )
   }
+
+  test(
+    "the trait cannot be applied with jsonName"
+  ) {
+    val source =
+      """|$version: "2"
+         |
+         |namespace test
+         |
+         |use alloy#jsonUnknown
+         |
+         |union MyOpenUnion {
+         |  @jsonUnknown
+         |  @jsonName("other")
+         |  unknown: Document
+         |}
+         |""".stripMargin
+
+    val result =
+      Model.assembler
+        .discoverModels()
+        .addUnparsedModel("/test.smithy", source)
+        .assemble()
+
+    assert(result.isBroken())
+
+    val eventIds = result
+      .getValidationEvents()
+      .asScala
+      .map(_.getId())
+      .toList
+
+    assert(
+      eventIds
+        .contains("TraitConflict"),
+      s"validation events should contain one with ID: TraitConflict. Found: $eventIds"
+    )
+  }
 }

--- a/modules/core/test/src/alloy/JsonUnknownTraitProviderSpec.scala
+++ b/modules/core/test/src/alloy/JsonUnknownTraitProviderSpec.scala
@@ -203,4 +203,43 @@ final class JsonUnknownTraitProviderSpec extends munit.FunSuite {
       s"validation events should contain one with ID: TraitTarget. Found: $eventIds"
     )
   }
+
+  test(
+    "the trait cannot be applied to untagged unions"
+  ) {
+    val source =
+      """|$version: "2"
+         |
+         |namespace test
+         |
+         |use alloy#jsonUnknown
+         |use alloy#untagged
+         |
+         |@untagged
+         |union MyOpenUnion {
+         |  @jsonUnknown
+         |  unknown: Document
+         |}
+         |""".stripMargin
+
+    val result =
+      Model.assembler
+        .discoverModels()
+        .addUnparsedModel("/test.smithy", source)
+        .assemble()
+
+    assert(result.isBroken())
+
+    val eventIds = result
+      .getValidationEvents()
+      .asScala
+      .map(_.getId())
+      .toList
+
+    assert(
+      eventIds
+        .contains("TraitTarget"),
+      s"validation events should contain one with ID: TraitTarget. Found: $eventIds"
+    )
+  }
 }

--- a/modules/core/test/src/alloy/validation/DiscriminatedUnionValidatorSpec.scala
+++ b/modules/core/test/src/alloy/validation/DiscriminatedUnionValidatorSpec.scala
@@ -86,7 +86,6 @@ final class DiscriminatedUnionValidatorSpec extends munit.FunSuite {
         .addUnparsedModel("/test.smithy", source)
         .assemble()
 
-    result.getValidationEvents().asScala.foreach(println)
     assert(!result.isBroken())
   }
 

--- a/modules/core/test/src/alloy/validation/DiscriminatedUnionValidatorSpec.scala
+++ b/modules/core/test/src/alloy/validation/DiscriminatedUnionValidatorSpec.scala
@@ -63,6 +63,33 @@ final class DiscriminatedUnionValidatorSpec extends munit.FunSuite {
     assertEquals(result, expected)
   }
 
+  test("allow unions with non-structure members if they're @jsonUnknown") {
+    val source =
+      """|$version: "2"
+         |
+         |namespace test
+         |
+         |use alloy#discriminated
+         |use alloy#jsonUnknown
+         |
+         |@discriminated("type")
+         |union MyOpenUnion {
+         |  first: Unit
+         |  @jsonUnknown
+         |  second: Document
+         |}
+         |""".stripMargin
+
+    val result =
+      Model.assembler
+        .discoverModels()
+        .addUnparsedModel("/test.smithy", source)
+        .assemble()
+
+    result.getValidationEvents().asScala.foreach(println)
+    assert(!result.isBroken())
+  }
+
   test("return error when target structures contain discriminator") {
     val struct = StructureShape
       .builder()

--- a/modules/openapi/src/alloy/openapi/DiscriminatedUnionMemberComponents.scala
+++ b/modules/openapi/src/alloy/openapi/DiscriminatedUnionMemberComponents.scala
@@ -168,6 +168,19 @@ class DiscriminatedUnionMemberComponents() extends OpenApiMapper {
             .build()
         )
 
+    val unknownPart = Schema
+      .builder()
+      .allOf(
+        List(
+          unionMixinRef,
+          Schema
+            .builder()
+            .additionalProperties(Schema.fromNode(Node.from(true)))
+            .build()
+        ).asJava
+      )
+      .build
+
     val base =
       schemaBuilder.removeExtension(DiscriminatedUnionShapeId.SHAPE_ID_KEY)
 
@@ -175,18 +188,7 @@ class DiscriminatedUnionMemberComponents() extends OpenApiMapper {
       base.oneOf(
         List(
           createKnownPart(Schema.builder()).build(),
-          Schema
-            .builder()
-            .allOf(
-              List(
-                unionMixinRef,
-                Schema
-                  .builder()
-                  .additionalProperties(Schema.fromNode(Node.from(true)))
-                  .build()
-              ).asJava
-            )
-            .build
+          unknownPart
         ).asJava
       )
     else

--- a/modules/openapi/src/alloy/openapi/DiscriminatedUnionMemberComponents.scala
+++ b/modules/openapi/src/alloy/openapi/DiscriminatedUnionMemberComponents.scala
@@ -28,6 +28,7 @@ import software.amazon.smithy.model.traits.JsonNameTrait
 import software.amazon.smithy.model.node.ObjectNode
 import software.amazon.smithy.jsonschema.Schema.Builder
 import alloy.JsonUnknownTrait
+import software.amazon.smithy.model.node.Node
 
 /** Creates components for the discriminated union
   */
@@ -181,7 +182,7 @@ class DiscriminatedUnionMemberComponents() extends OpenApiMapper {
                 unionMixinRef,
                 Schema
                   .builder()
-                  .additionalProperties(Schema.builder().build())
+                  .additionalProperties(Schema.fromNode(Node.from(true)))
                   .build()
               ).asJava
             )

--- a/modules/openapi/src/alloy/openapi/DiscriminatedUnionMemberComponents.scala
+++ b/modules/openapi/src/alloy/openapi/DiscriminatedUnionMemberComponents.scala
@@ -27,6 +27,7 @@ import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.traits.JsonNameTrait
 import software.amazon.smithy.model.node.ObjectNode
 import software.amazon.smithy.jsonschema.Schema.Builder
+import alloy.JsonUnknownTrait
 
 /** Creates components for the discriminated union
   */
@@ -55,7 +56,7 @@ class DiscriminatedUnionMemberComponents() extends OpenApiMapper {
           }
       }
     unions.asScala
-      .filter(u => componentSchemas.contains(u.toShapeId))
+      .filter(u => componentSchemas.contains(u.getId()))
       .foreach { union =>
         val unionMixinName = union.getId().getName() + "Mixin"
         val unionMixinId =
@@ -81,20 +82,25 @@ class DiscriminatedUnionMemberComponents() extends OpenApiMapper {
 
         componentBuilder.putSchema(unionMixinName, unionMixinSchema)
 
-        union.members().asScala.foreach { memberShape =>
-          val syntheticMemberName =
-            union.getId().getName() + memberShape.getMemberName.capitalize
-          context.getPointer(union).split('/').last + memberShape
-            .getMemberName()
-            .capitalize
-          val targetRef = context.createRef(memberShape.getTarget())
-          val syntheticUnionMember =
-            Schema
-              .builder()
-              .allOf(List(targetRef, unionMixinRef).asJava)
-              .build()
-          componentBuilder.putSchema(syntheticMemberName, syntheticUnionMember)
-        }
+        union
+          .members()
+          .asScala
+          .filterNot(m => m.hasTrait(classOf[JsonUnknownTrait]))
+          .foreach { memberShape =>
+            val syntheticMemberName =
+              union.getId().getName() + memberShape.getMemberName.capitalize
+            context.getPointer(union).split('/').last + memberShape
+              .getMemberName()
+              .capitalize
+            val targetRef = context.createRef(memberShape.getTarget())
+            val syntheticUnionMember =
+              Schema
+                .builder()
+                .allOf(List(targetRef, unionMixinRef).asJava)
+                .build()
+            componentBuilder
+              .putSchema(syntheticMemberName, syntheticUnionMember)
+          }
 
         componentSchemas.get(union.toShapeId).foreach { sch =>
           componentBuilder.putSchema(
@@ -102,7 +108,8 @@ class DiscriminatedUnionMemberComponents() extends OpenApiMapper {
             updateDiscriminatedUnion(
               union,
               sch.toBuilder(),
-              discriminatorField
+              discriminatorField,
+              unionMixinRef
             )
               .build()
           )
@@ -115,25 +122,29 @@ class DiscriminatedUnionMemberComponents() extends OpenApiMapper {
   private def updateDiscriminatedUnion(
       shape: Shape,
       schemaBuilder: Builder,
-      discriminatorField: String
+      discriminatorField: String,
+      unionMixinRef: Schema
   ): Builder = {
-    val alts = shape
+    val (unknownMember, knownMembers) = shape
       .members()
       .asScala
-      .map { member =>
-        val label = member
-          .getTrait(classOf[JsonNameTrait])
-          .asScala
-          .map(_.getValue())
-          .getOrElse(member.getMemberName())
-        val syntheticMemberId =
-          shape.getId().getName() + member.getMemberName().capitalize
-        val refString = s"#/components/schemas/$syntheticMemberId"
-        val refSchema =
-          Schema.builder.ref(refString).build
-        (label, refString, refSchema)
-      }
       .toList
+      .partition(_.hasTrait(classOf[JsonUnknownTrait]))
+
+    val alts = knownMembers.map { member =>
+      val label = member
+        .getTrait(classOf[JsonNameTrait])
+        .asScala
+        .map(_.getValue())
+        .getOrElse(member.getMemberName())
+      val syntheticMemberId =
+        shape.getId().getName() + member.getMemberName().capitalize
+      val refString = s"#/components/schemas/$syntheticMemberId"
+      val refSchema =
+        Schema.builder.ref(refString).build
+      (label, refString, refSchema)
+    }.toList
+
     val schemas = alts.map(_._3).asJava
     val mapping = ObjectNode.fromStringMap(
       alts
@@ -141,17 +152,33 @@ class DiscriminatedUnionMemberComponents() extends OpenApiMapper {
         .toMap
         .asJava
     )
-    schemaBuilder
-      .removeExtension(DiscriminatedUnionShapeId.SHAPE_ID_KEY)
-      .oneOf(schemas)
-      .putExtension(
-        "discriminator",
-        ObjectNode
-          .builder()
-          .withMember("propertyName", discriminatorField)
-          .withMember("mapping", mapping)
-          .build()
+
+    val isOpen =
+      unknownMember.nonEmpty
+
+    def createKnownPart(b: Schema.Builder): Schema.Builder =
+      b.oneOf(schemas)
+        .putExtension(
+          "discriminator",
+          ObjectNode
+            .builder()
+            .withMember("propertyName", discriminatorField)
+            .withMember("mapping", mapping)
+            .build()
+        )
+
+    val base =
+      schemaBuilder.removeExtension(DiscriminatedUnionShapeId.SHAPE_ID_KEY)
+
+    if (isOpen)
+      base.oneOf(
+        List(
+          createKnownPart(Schema.builder()).build(),
+          unionMixinRef
+        ).asJava
       )
+    else
+      createKnownPart(base)
   }
 
 }

--- a/modules/openapi/src/alloy/openapi/DiscriminatedUnionMemberComponents.scala
+++ b/modules/openapi/src/alloy/openapi/DiscriminatedUnionMemberComponents.scala
@@ -174,7 +174,18 @@ class DiscriminatedUnionMemberComponents() extends OpenApiMapper {
       base.oneOf(
         List(
           createKnownPart(Schema.builder()).build(),
-          unionMixinRef
+          Schema
+            .builder()
+            .allOf(
+              List(
+                unionMixinRef,
+                Schema
+                  .builder()
+                  .additionalProperties(Schema.builder().build())
+                  .build()
+              ).asJava
+            )
+            .build
         ).asJava
       )
     else

--- a/modules/openapi/src/alloy/openapi/JsonUnknownMapper.scala
+++ b/modules/openapi/src/alloy/openapi/JsonUnknownMapper.scala
@@ -49,7 +49,7 @@ class JsonUnknownMapper() extends JsonSchemaMapper {
       if (shape.isStructureShape()) {
         schemaBuilder
           .removeProperty(unknownMember.getMemberName)
-          .additionalProperties(Schema.fromNode(Node.objectNode()))
+          .additionalProperties(Schema.fromNode(Node.from(true)))
       } else if (
         shape
           .isUnionShape() && !shape.hasTrait(classOf[DiscriminatedUnionTrait])
@@ -68,7 +68,7 @@ class JsonUnknownMapper() extends JsonSchemaMapper {
                   .toBuilder()
                   .required(Nil.asJava)
                   .properties(Map.empty.asJava)
-                  .additionalProperties(Schema.fromNode(Node.objectNode()))
+                  .additionalProperties(Schema.fromNode(Node.from(true)))
                   .build()
               case other => other
             }

--- a/modules/openapi/src/alloy/openapi/JsonUnknownMapper.scala
+++ b/modules/openapi/src/alloy/openapi/JsonUnknownMapper.scala
@@ -32,19 +32,21 @@ class JsonUnknownMapper() extends JsonSchemaMapper {
       schemaBuilder: Builder,
       config: JsonSchemaConfig
   ): Builder = {
-    val jsonUnknownMemberName = shape
-      .getAllMembers()
-      .asScala
-      .collect {
-        case (name, member) if member.hasTrait(classOf[JsonUnknownTrait]) =>
-          name
-      }
-      .headOption
+    if (shape.isStructureShape()) {
+      val jsonUnknownMemberName = shape
+        .getAllMembers()
+        .asScala
+        .collect {
+          case (name, member) if member.hasTrait(classOf[JsonUnknownTrait]) =>
+            name
+        }
+        .headOption
 
-    jsonUnknownMemberName.fold(schemaBuilder) { name =>
-      schemaBuilder
-        .removeProperty(name)
-        .putExtension(ADDITIONAL_PROPERTIES, Node.from(true))
-    }
+      jsonUnknownMemberName.fold(schemaBuilder) { name =>
+        schemaBuilder
+          .removeProperty(name)
+          .putExtension(ADDITIONAL_PROPERTIES, Node.from(true))
+      }
+    } else schemaBuilder
   }
 }

--- a/modules/openapi/test/resources/foo.json
+++ b/modules/openapi/test/resources/foo.json
@@ -368,13 +368,7 @@
           },
           {
             "type": "object",
-            "title": "other",
-            "properties": {
-              "other": {}
-            },
-            "required": [
-              "other"
-            ]
+            "title": "other"
           }
         ]
       },

--- a/modules/openapi/test/resources/foo.json
+++ b/modules/openapi/test/resources/foo.json
@@ -381,23 +381,26 @@
       "CatOrDogOpenDiscriminated": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedCat"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedCat"
+              },
+              {
+                "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedDog"
+              }
+            ],
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "cat": "#/components/schemas/CatOrDogOpenDiscriminatedCat",
+                "dog": "#/components/schemas/CatOrDogOpenDiscriminatedDog"
+              }
+            }
           },
           {
-            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedDog"
-          },
-          {
-            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedOther"
+            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
           }
-        ],
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "cat": "#/components/schemas/CatOrDogOpenDiscriminatedCat",
-            "dog": "#/components/schemas/CatOrDogOpenDiscriminatedDog",
-            "other": "#/components/schemas/CatOrDogOpenDiscriminatedOther"
-          }
-        }
+        ]
       },
       "CatOrDogOpenDiscriminatedCat": {
         "allOf": [
@@ -428,16 +431,6 @@
         },
         "required": [
           "type"
-        ]
-      },
-      "CatOrDogOpenDiscriminatedOther": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Document"
-          },
-          {
-            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
-          }
         ]
       },
       "Dog": {

--- a/modules/openapi/test/resources/foo.json
+++ b/modules/openapi/test/resources/foo.json
@@ -368,6 +368,7 @@
           },
           {
             "type": "object",
+            "additionalProperties": {},
             "title": "other"
           }
         ]
@@ -392,7 +393,14 @@
             }
           },
           {
-            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
+              },
+              {
+                "additionalProperties": {}
+              }
+            ]
           }
         ]
       },
@@ -429,6 +437,7 @@
       },
       "Dog": {
         "type": "object",
+        "additionalProperties": {},
         "properties": {
           "name": {
             "type": "string"
@@ -437,7 +446,6 @@
             "type": "string"
           }
         },
-        "additionalProperties": true,
         "example": {
           "name": "Woof"
         }

--- a/modules/openapi/test/resources/foo.json
+++ b/modules/openapi/test/resources/foo.json
@@ -368,7 +368,7 @@
           },
           {
             "type": "object",
-            "additionalProperties": {},
+            "additionalProperties": true,
             "title": "other"
           }
         ]
@@ -398,7 +398,7 @@
                 "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
               },
               {
-                "additionalProperties": {}
+                "additionalProperties": true
               }
             ]
           }
@@ -437,7 +437,7 @@
       },
       "Dog": {
         "type": "object",
-        "additionalProperties": {},
+        "additionalProperties": true,
         "properties": {
           "name": {
             "type": "string"

--- a/modules/openapi/test/resources/foo.json
+++ b/modules/openapi/test/resources/foo.json
@@ -340,6 +340,106 @@
           "type"
         ]
       },
+      "CatOrDogOpen": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "cat",
+            "properties": {
+              "cat": {
+                "$ref": "#/components/schemas/Cat"
+              }
+            },
+            "required": [
+              "cat"
+            ]
+          },
+          {
+            "type": "object",
+            "title": "dog",
+            "properties": {
+              "dog": {
+                "$ref": "#/components/schemas/Dog"
+              }
+            },
+            "required": [
+              "dog"
+            ]
+          },
+          {
+            "type": "object",
+            "title": "other",
+            "properties": {
+              "other": {}
+            },
+            "required": [
+              "other"
+            ]
+          }
+        ]
+      },
+      "CatOrDogOpenDiscriminated": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedCat"
+          },
+          {
+            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedDog"
+          },
+          {
+            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedOther"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "cat": "#/components/schemas/CatOrDogOpenDiscriminatedCat",
+            "dog": "#/components/schemas/CatOrDogOpenDiscriminatedDog",
+            "other": "#/components/schemas/CatOrDogOpenDiscriminatedOther"
+          }
+        }
+      },
+      "CatOrDogOpenDiscriminatedCat": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Cat"
+          },
+          {
+            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
+          }
+        ]
+      },
+      "CatOrDogOpenDiscriminatedDog": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Dog"
+          },
+          {
+            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
+          }
+        ]
+      },
+      "CatOrDogOpenDiscriminatedMixin": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "CatOrDogOpenDiscriminatedOther": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Document"
+          },
+          {
+            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
+          }
+        ]
+      },
       "Dog": {
         "type": "object",
         "properties": {
@@ -409,6 +509,12 @@
           },
           "catOrDog": {
             "$ref": "#/components/schemas/CatOrDog"
+          },
+          "catOrDogOpen": {
+            "$ref": "#/components/schemas/CatOrDogOpen"
+          },
+          "catOrDogOpenDiscriminated": {
+            "$ref": "#/components/schemas/CatOrDogOpenDiscriminated"
           }
         }
       },

--- a/modules/openapi/test/resources/foo.smithy
+++ b/modules/openapi/test/resources/foo.smithy
@@ -179,6 +179,8 @@ structure GetUnionResponse {
     intOrString: IntOrString
     doubleOrFloat: DoubleOrFloat
     catOrDog: CatOrDog
+    catOrDogOpen: CatOrDogOpen
+    catOrDogOpenDiscriminated: CatOrDogOpenDiscriminated
 }
 
 union IntOrString {
@@ -243,4 +245,23 @@ union SomeValue {
 union CatOrDog {
     cat: Cat
     dog: Dog
+}
+
+union CatOrDogOpen {
+    cat: Cat
+
+    dog: Dog
+
+    @jsonUnknown
+    other: Document
+}
+
+@discriminated("type")
+union CatOrDogOpenDiscriminated {
+    cat: Cat
+
+    dog: Dog
+
+    @jsonUnknown
+    other: Document
 }

--- a/modules/openapi/test/src/alloy/openapi/OpenApiConversionSpec.scala
+++ b/modules/openapi/test/src/alloy/openapi/OpenApiConversionSpec.scala
@@ -40,12 +40,20 @@ final class OpenApiConversionSpec extends munit.FunSuite {
       .mkString
       .filterNot(_.isWhitespace)
 
-    val expected = Using
-      .resource(Source.fromResource("foo.json"))(
-        _.getLines().mkString.filterNot(_.isWhitespace)
-      )
+    val expected = os.read(os.resource / "foo.json").filterNot(_.isWhitespace)
 
-    assertEquals(result, expected)
+    if (result != expected) {
+      val tmp = os.pwd / "actual" / "foo.json"
+
+      os.write.over(
+        tmp,
+        Node.prettyPrintJson(Node.parse(result)),
+        createFolders = true
+      )
+      fail(
+        s"Values are not the same. Wrote current output to $tmp for easier debugging."
+      )
+    }
   }
 
   test(

--- a/modules/protocol-tests/resources/META-INF/smithy/OpenUnions.smithy
+++ b/modules/protocol-tests/resources/META-INF/smithy/OpenUnions.smithy
@@ -1,0 +1,163 @@
+$version: "2"
+
+namespace alloy.test
+
+use alloy#simpleRestJson
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+apply OpenUnions @httpRequestTests([
+    {
+        id: "OpenUnionsKnownTaggedUnionCase"
+        documentation: "Pass a known tagged union value in an open union"
+        protocol: simpleRestJson
+        method: "PUT"
+        uri: "/openUnions"
+        body: """
+            {"tagged": {"str": "string value"}}"""
+        headers: { "Content-Type": "application/json" }
+        requireHeaders: ["Content-Length"]
+        params: {
+            data: {
+                tagged: { str: "string value" }
+            }
+        }
+        bodyMediaType: "application/json"
+    }
+    {
+        id: "OpenUnionsUnknownTaggedUnionCase"
+        documentation: "Pass an unknown tagged union value in an open union"
+        protocol: simpleRestJson
+        method: "PUT"
+        uri: "/openUnions"
+        body: """
+            {"tagged": {"whatisthis": {"nested": "something different"}}}"""
+        headers: { "Content-Type": "application/json" }
+        requireHeaders: ["Content-Length"]
+        params: {
+            data: {
+                tagged: {
+                    other: {
+                        whatisthis: { nested: "something different" }
+                    }
+                }
+            }
+        }
+        bodyMediaType: "application/json"
+    }
+    {
+        id: "OpenUnionsKnownDiscriminatedUnionCase"
+        documentation: "Pass a known discriminated union value in an open union"
+        protocol: simpleRestJson
+        method: "PUT"
+        uri: "/openUnions"
+        body: """
+            {"discriminated": {"key": "smol", "content": "some string"}}"""
+        headers: { "Content-Type": "application/json" }
+        requireHeaders: ["Content-Length"]
+        params: {
+            data: {
+                discriminated: {
+                    smol: { content: "some string" }
+                }
+            }
+        }
+        bodyMediaType: "application/json"
+    }
+    {
+        id: "OpenUnionsUnknownDiscriminatedUnionCase"
+        documentation: "Pass an unknown discriminated union value in an open union"
+        protocol: simpleRestJson
+        method: "PUT"
+        uri: "/openUnions"
+        body: """
+            {\"discriminated\": {\"key\": \"mysterious_and_important\", \"extras\": 42}}"""
+        headers: { "Content-Type": "application/json" }
+        requireHeaders: ["Content-Length"]
+        params: {
+            data: {
+                discriminated: {
+                    other: {
+                        key: "mysterious_and_important"
+                        extras: 42
+                    }
+                }
+            }
+        }
+        bodyMediaType: "application/json"
+    }
+])
+
+apply OpenUnions @httpResponseTests([
+    {
+        id: "OpenUnionsKnownTaggedUnionCase"
+        code: 200
+        documentation: "Return a known tagged union value in an open union"
+        protocol: simpleRestJson
+        body: """
+            {"tagged": {"str": "string value"}}"""
+        headers: { "Content-Type": "application/json" }
+        params: {
+            data: {
+                tagged: { str: "string value" }
+            }
+        }
+        bodyMediaType: "application/json"
+    }
+    {
+        id: "OpenUnionsUnknownTaggedUnionCase"
+        code: 200
+        documentation: "Return an unknown tagged union value in an open union"
+        protocol: simpleRestJson
+        body: """
+            {"tagged": {"whatisthis": {"nested": "something different"}}}"""
+        headers: { "Content-Type": "application/json" }
+        params: {
+            data: {
+                tagged: {
+                    other: {
+                        whatisthis: { nested: "something different" }
+                    }
+                }
+            }
+        }
+        bodyMediaType: "application/json"
+    }
+    {
+        id: "OpenUnionsKnownDiscriminatedUnionCase"
+        code: 200
+        documentation: "Return a known discriminated union value in an open union"
+        protocol: simpleRestJson
+        body: """
+            {"discriminated": {"key": "smol", "content": "some string"}}"""
+        headers: { "Content-Type": "application/json" }
+        params: {
+            data: {
+                discriminated: {
+                    smol: { content: "some string" }
+                }
+            }
+        }
+        bodyMediaType: "application/json"
+    }
+    {
+        id: "OpenUnionsUnknownDiscriminatedUnionCase"
+        code: 200
+        documentation: "Return an unknown discriminated union value in an open union"
+        protocol: simpleRestJson
+        body: """
+            {\"discriminated\": {\"key\": \"mysterious_and_important\", \"extras\": 42}}"""
+        headers: { "Content-Type": "application/json" }
+        params: {
+            data: {
+                discriminated: {
+                    other: {
+                        key: "mysterious_and_important"
+                        extras: 42
+                    }
+                }
+            }
+        }
+        bodyMediaType: "application/json"
+    }
+])

--- a/modules/protocol-tests/resources/META-INF/smithy/Pizza.smithy
+++ b/modules/protocol-tests/resources/META-INF/smithy/Pizza.smithy
@@ -3,12 +3,14 @@ $version: "2"
 namespace alloy.test
 
 use alloy#simpleRestJson
+use alloy#jsonUnknown
+use alloy#discriminated
 
 @simpleRestJson
 service PizzaAdminService {
     version: "1.0.0",
     errors: [GenericServerError, GenericClientError],
-    operations: [AddMenuItem, GetMenu, Version, Health, HeaderEndpoint, RoundTrip, GetEnum, GetIntEnum, CustomCode, HttpPayloadWithDefault, HttpPayloadRequiredWithDefault]
+    operations: [AddMenuItem, GetMenu, Version, Health, HeaderEndpoint, RoundTrip, GetEnum, GetIntEnum, CustomCode, HttpPayloadWithDefault, HttpPayloadRequiredWithDefault, OpenUnions]
 }
 
 @http(method: "POST", uri: "/restaurant/{restaurant}/menu/item", code: 201)
@@ -328,4 +330,35 @@ structure HttpPayloadRequiredWithDefaultInputOutput {
     @default("default value")
     @required
     body: String
+}
+
+@idempotent
+@http(uri: "/openUnions", method: "PUT")
+operation OpenUnions {
+    input := {
+      @required @httpPayload data: OpenUnionsPayload
+    }
+    output := {
+        @required @httpPayload data: OpenUnionsPayload
+    }
+}
+
+union OpenUnionsPayload {
+    tagged: OpenTaggedUnion
+    discriminated: OpenDiscriminatedUnion
+}
+
+union OpenTaggedUnion {
+    str: String
+    @jsonUnknown other: Document
+}
+
+@discriminated("key")
+union OpenDiscriminatedUnion {
+    smol: SmallStruct
+    @jsonUnknown other: Document
+}
+
+structure SmallStruct {
+    @required content: String
 }

--- a/modules/protocol-tests/resources/META-INF/smithy/manifest
+++ b/modules/protocol-tests/resources/META-INF/smithy/manifest
@@ -10,3 +10,4 @@ RoundTrip.smithy
 Version.smithy
 HttpPayloadWithDefault.smithy
 test-config.json
+OpenUnions.smithy


### PR DESCRIPTION
Closes the protocol side of https://github.com/disneystreaming/smithy4s/issues/1585.

Scala counterpart: https://github.com/disneystreaming/smithy4s/pull/1677

- [x] Ensure only one union member can be tagged with this
- [x] Ensure only documents can be targetted
- [x] Support in OpenAPI
- [x] Some protocol compliance tests
- [x] Documentation