### PR TITLE
Add an encoded character to the GetMenu request tests

### DIFF
--- a/modules/protocol-tests/resources/META-INF/smithy/GetMenu.smithy
+++ b/modules/protocol-tests/resources/META-INF/smithy/GetMenu.smithy
@@ -11,14 +11,13 @@ apply GetMenu @httpRequestTests([
     {
         id: "GetMenuRequest"
         protocol: simpleRestJson
-        uri: "/restaurant/unclemikes/menu"
+        uri: "/restaurant/uncle%3Amikes/menu"
         method: "GET"
         params: {
-            restaurant: "unclemikes"
+            restaurant: "uncle:mikes"
         }
     }
 ])
-
 
 apply GetMenu @httpResponseTests([
     {


### PR DESCRIPTION
The [Smithy spec](https://smithy.io/2.0/spec/http-bindings.html#id7) says that in HTTP labels used in HTTP request URIs,

> Characters not defined as unreserved by [RFC 3986 section 2.3](https://datatracker.ietf.org/doc/html/rfc3986.html#section-2.3) MUST be [percent-encoded](https://datatracker.ietf.org/doc/html/rfc3986.html#section-2.1). That is, all characters except for alphanumerics and `-._~`.

This PR adds an example of such a character used in the value bound to the `GetMenu` request's `{restaurant}` label, along with the expected encoding.