### PR TITLE
Fix OpenAPI bug where generated name conflicts with existing name

### DIFF
--- a/modules/openapi/src/alloy/openapi/DiscriminatedUnionMemberComponents.scala
+++ b/modules/openapi/src/alloy/openapi/DiscriminatedUnionMemberComponents.scala
@@ -89,7 +89,7 @@ class DiscriminatedUnionMemberComponents() extends OpenApiMapper {
           .filterNot(m => m.hasTrait(classOf[JsonUnknownTrait]))
           .foreach { memberShape =>
             val syntheticMemberName =
-              union.getId().getName() + memberShape.getMemberName.capitalize
+              "Synthetic" + union.getId().getName().capitalize + memberShape.getMemberName.capitalize
             context.getPointer(union).split('/').last + memberShape
               .getMemberName()
               .capitalize
@@ -139,7 +139,7 @@ class DiscriminatedUnionMemberComponents() extends OpenApiMapper {
         .map(_.getValue())
         .getOrElse(member.getMemberName())
       val syntheticMemberId =
-        shape.getId().getName() + member.getMemberName().capitalize
+        "Synthetic" + shape.getId().getName().capitalize + member.getMemberName().capitalize
       val refString = s"#/components/schemas/$syntheticMemberId"
       val refSchema =
         Schema.builder.ref(refString).build

--- a/modules/openapi/src/alloy/openapi/DiscriminatedUnionMemberComponents.scala
+++ b/modules/openapi/src/alloy/openapi/DiscriminatedUnionMemberComponents.scala
@@ -89,10 +89,10 @@ class DiscriminatedUnionMemberComponents() extends OpenApiMapper {
           .filterNot(m => m.hasTrait(classOf[JsonUnknownTrait]))
           .foreach { memberShape =>
             val syntheticMemberName =
-              "Synthetic" + union.getId().getName().capitalize + memberShape.getMemberName.capitalize
-            context.getPointer(union).split('/').last + memberShape
-              .getMemberName()
-              .capitalize
+              "Synthetic" + union
+                .getId()
+                .getName()
+                .capitalize + memberShape.getMemberName.capitalize
             val targetRef = context.createRef(memberShape.getTarget())
             val syntheticUnionMember =
               Schema
@@ -139,7 +139,9 @@ class DiscriminatedUnionMemberComponents() extends OpenApiMapper {
         .map(_.getValue())
         .getOrElse(member.getMemberName())
       val syntheticMemberId =
-        "Synthetic" + shape.getId().getName().capitalize + member.getMemberName().capitalize
+        "Synthetic" + shape.getId().getName().capitalize + member
+          .getMemberName()
+          .capitalize
       val refString = s"#/components/schemas/$syntheticMemberId"
       val refSchema =
         Schema.builder.ref(refString).build

--- a/modules/openapi/test/resources/foo.json
+++ b/modules/openapi/test/resources/foo.json
@@ -1,699 +1,625 @@
 {
-    "openapi": "3.0.2",
-    "info": {
-        "title": "HelloWorldService",
-        "version": "0.0.1"
-    },
-    "paths": {
-        "/default": {
-            "get": {
-                "operationId": "GetUnion",
-                "responses": {
-                    "200": {
-                        "description": "GetUnion200response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GetUnionResponseContent"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "GeneralServerError500response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GeneralServerErrorResponseContent"
-                                }
-                            }
-                        }
-                    }
+  "openapi": "3.0.2",
+  "info": {
+    "title": "HelloWorldService",
+    "version": "0.0.1"
+  },
+  "paths": {
+    "/default": {
+      "get": {
+        "operationId": "GetUnion",
+        "responses": {
+          "200": {
+            "description": "GetUnion200response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetUnionResponseContent"
                 }
+              }
             }
-        },
-        "/hello/{name}/{ts}": {
-            "get": {
-                "externalDocs": {
-                    "description": "APIHomepage2",
-                    "url": "https://www.example2.com/"
-                },
-                "operationId": "Greet",
-                "parameters": [
-                    {
-                        "name": "name",
-                        "in": "path",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "required": true
-                    },
-                    {
-                        "name": "ts",
-                        "in": "path",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time"
-                        },
-                        "required": true
-                    },
-                    {
-                        "name": "from",
-                        "in": "query",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time"
-                        }
-                    },
-                    {
-                        "name": "whenThree",
-                        "in": "header",
-                        "schema": {
-                            "type": "string",
-                            "format": "date-time"
-                        }
-                    },
-                    {
-                        "name": "whenFour",
-                        "in": "header",
-                        "schema": {
-                            "type": "string",
-                            "format": "epoch-seconds"
-                        }
-                    },
-                    {
-                        "name": "X-Bamtech-Partner",
-                        "in": "header",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "when",
-                        "in": "header",
-                        "schema": {
-                            "type": "string",
-                            "format": "http-date"
-                        }
-                    },
-                    {
-                        "name": "whenAlso",
-                        "in": "header",
-                        "schema": {
-                            "type": "string",
-                            "format": "http-date"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Greet200response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GreetOutputPayload"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "404Response",
-                        "headers": {
-                            "x-error-one": {
-                                "schema": {
-                                    "type": "string"
-                                },
-                                "required": true
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "GeneralServerError500response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GeneralServerErrorResponseContent"
-                                }
-                            }
-                        }
-                    }
+          },
+          "500": {
+            "description": "GeneralServerError500response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralServerErrorResponseContent"
                 }
+              }
             }
-        },
-        "/test_errors": {
-            "post": {
-                "operationId": "TestErrorsInExamples",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/TestErrorsInExamplesRequestContent"
-                            },
-                            "examples": {
-                                "ONE": {
-                                    "value": {
-                                        "in": "testinput"
-                                    }
-                                },
-                                "THREE": {
-                                    "value": {
-                                        "in": "testinputthree"
-                                    }
-                                },
-                                "TWO": {
-                                    "value": {
-                                        "in": "testinputtwo"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "TestErrorsInExamples200response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TestErrorsInExamplesResponseContent"
-                                },
-                                "examples": {
-                                    "ONE": {
-                                        "value": {
-                                            "out": "testoutput"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "404Response",
-                        "headers": {
-                            "x-one": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "x-three": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "x-two": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "oneOf": [
-                                        {
-                                            "$ref": "#/components/schemas/NotFoundResponseContent"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/NotFoundTwoResponseContent"
-                                        }
-                                    ]
-                                },
-                                "examples": {
-                                    "THREE": {
-                                        "value": {
-                                            "messageTwo": "Notfoundmessagetwo"
-                                        }
-                                    },
-                                    "TWO": {
-                                        "value": {
-                                            "message": "Notfoundmessage"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "GeneralServerError500response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GeneralServerErrorResponseContent"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/values": {
-            "get": {
-                "operationId": "GetValues",
-                "responses": {
-                    "200": {
-                        "description": "GetValues200response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GetValuesResponseContent"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "GeneralServerError500response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GeneralServerErrorResponseContent"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+          }
         }
+      }
     },
-    "components": {
-        "schemas": {
-            "Cat": {
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    }
-                },
-                "example": {
-                    "name": "Meow"
-                }
+    "/hello/{name}/{ts}": {
+      "get": {
+        "externalDocs": {
+          "description": "APIHomepage2",
+          "url": "https://www.example2.com/"
+        },
+        "operationId": "Greet",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "schema": {
+              "type": "string"
             },
-            "CatOrDog": {
-                "oneOf": [
-                    {
-                        "$ref": "#/components/schemas/SyntheticCatOrDogCat"
-                    },
-                    {
-                        "$ref": "#/components/schemas/SyntheticCatOrDogDog"
-                    }
-                ],
-                "externalDocs": {
-                    "description": "Homepage",
-                    "url": "https://www.example.com/"
-                },
-                "discriminator": {
-                    "propertyName": "type",
-                    "mapping": {
-                        "cat": "#/components/schemas/SyntheticCatOrDogCat",
-                        "dog": "#/components/schemas/SyntheticCatOrDogDog"
-                    }
-                }
+            "required": true
+          },
+          {
+            "name": "ts",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
             },
-            "CatOrDogMixin": {
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "type"
-                ]
-            },
-            "CatOrDogOpen": {
-                "oneOf": [
-                    {
-                        "type": "object",
-                        "title": "cat",
-                        "properties": {
-                            "cat": {
-                                "$ref": "#/components/schemas/Cat"
-                            }
-                        },
-                        "required": [
-                            "cat"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "dog",
-                        "properties": {
-                            "dog": {
-                                "$ref": "#/components/schemas/Dog"
-                            }
-                        },
-                        "required": [
-                            "dog"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "additionalProperties": true,
-                        "title": "other"
-                    }
-                ]
-            },
-            "CatOrDogOpenDiscriminated": {
-                "oneOf": [
-                    {
-                        "oneOf": [
-                            {
-                                "$ref": "#/components/schemas/SyntheticCatOrDogOpenDiscriminatedCat"
-                            },
-                            {
-                                "$ref": "#/components/schemas/SyntheticCatOrDogOpenDiscriminatedDog"
-                            }
-                        ],
-                        "discriminator": {
-                            "propertyName": "type",
-                            "mapping": {
-                                "cat": "#/components/schemas/SyntheticCatOrDogOpenDiscriminatedCat",
-                                "dog": "#/components/schemas/SyntheticCatOrDogOpenDiscriminatedDog"
-                            }
-                        }
-                    },
-                    {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
-                            },
-                            {
-                                "additionalProperties": true
-                            }
-                        ]
-                    }
-                ]
-            },
-            "CatOrDogOpenDiscriminatedMixin": {
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "type"
-                ]
-            },
-            "Dog": {
-                "type": "object",
-                "additionalProperties": true,
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "breed": {
-                        "type": "string"
-                    }
-                },
-                "example": {
-                    "name": "Woof"
-                }
-            },
-            "DoubleOrFloat": {
-                "oneOf": [
-                    {
-                        "type": "object",
-                        "title": "float",
-                        "properties": {
-                            "float": {
-                                "type": "number",
-                                "format": "float"
-                            }
-                        },
-                        "required": [
-                            "float"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "double",
-                        "properties": {
-                            "double": {
-                                "type": "number",
-                                "format": "double"
-                            }
-                        },
-                        "required": [
-                            "double"
-                        ]
-                    }
-                ]
-            },
-            "GeneralServerErrorResponseContent": {
-                "type": "object",
-                "properties": {
-                    "message": {
-                        "type": "string"
-                    },
-                    "count": {
-                        "type": "integer",
-                        "format": "int32",
-                        "nullable": true
-                    }
-                }
-            },
-            "GetUnionResponseContent": {
-                "type": "object",
-                "properties": {
-                    "intOrString": {
-                        "$ref": "#/components/schemas/IntOrString"
-                    },
-                    "doubleOrFloat": {
-                        "$ref": "#/components/schemas/DoubleOrFloat"
-                    },
-                    "catOrDog": {
-                        "$ref": "#/components/schemas/CatOrDog"
-                    },
-                    "catOrDogOpen": {
-                        "$ref": "#/components/schemas/CatOrDogOpen"
-                    },
-                    "catOrDogOpenDiscriminated": {
-                        "$ref": "#/components/schemas/CatOrDogOpenDiscriminated"
-                    },
-                    "vehicle": {
-                        "$ref": "#/components/schemas/Vehicle"
-                    }
-                }
-            },
-            "GetValuesResponseContent": {
-                "type": "object",
-                "properties": {
-                    "values": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/SomeValue"
-                        }
-                    }
-                },
-                "example": {
-                    "values": []
-                }
-            },
-            "GreetOutputPayload": {
-                "type": "string"
-            },
-            "IntOrString": {
-                "oneOf": [
-                    {
-                        "type": "object",
-                        "title": "int",
-                        "properties": {
-                            "int": {
-                                "type": "integer",
-                                "format": "int32"
-                            }
-                        },
-                        "required": [
-                            "int"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "title": "string",
-                        "properties": {
-                            "string": {
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "string"
-                        ]
-                    }
-                ]
-            },
-            "NotFoundResponseContent": {
-                "type": "object",
-                "properties": {
-                    "message": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "message"
-                ]
-            },
-            "NotFoundTwoResponseContent": {
-                "type": "object",
-                "properties": {
-                    "messageTwo": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "messageTwo"
-                ]
-            },
-            "SomeValue": {
-                "oneOf": [
-                    {
-                        "type": "string",
-                        "title": "message"
-                    },
-                    {
-                        "type": "integer",
-                        "title": "value",
-                        "format": "int32"
-                    }
-                ]
-            },
-            "SyntheticCatOrDogCat": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Cat"
-                    },
-                    {
-                        "$ref": "#/components/schemas/CatOrDogMixin"
-                    }
-                ]
-            },
-            "SyntheticCatOrDogDog": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Dog"
-                    },
-                    {
-                        "$ref": "#/components/schemas/CatOrDogMixin"
-                    }
-                ]
-            },
-            "SyntheticCatOrDogOpenDiscriminatedCat": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Cat"
-                    },
-                    {
-                        "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
-                    }
-                ]
-            },
-            "SyntheticCatOrDogOpenDiscriminatedDog": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/Dog"
-                    },
-                    {
-                        "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
-                    }
-                ]
-            },
-            "SyntheticVehicleCar": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/VehicleCar"
-                    },
-                    {
-                        "$ref": "#/components/schemas/VehicleMixin"
-                    }
-                ]
-            },
-            "SyntheticVehiclePlane": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/VehiclePlane"
-                    },
-                    {
-                        "$ref": "#/components/schemas/VehicleMixin"
-                    }
-                ]
-            },
-            "TestErrorsInExamplesRequestContent": {
-                "type": "object",
-                "properties": {
-                    "in": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "in"
-                ]
-            },
-            "TestErrorsInExamplesResponseContent": {
-                "type": "object",
-                "properties": {
-                    "out": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "out"
-                ]
-            },
-            "Vehicle": {
-                "oneOf": [
-                    {
-                        "$ref": "#/components/schemas/SyntheticVehicleCar"
-                    },
-                    {
-                        "$ref": "#/components/schemas/SyntheticVehiclePlane"
-                    }
-                ],
-                "discriminator": {
-                    "propertyName": "type",
-                    "mapping": {
-                        "car": "#/components/schemas/SyntheticVehicleCar",
-                        "plane": "#/components/schemas/SyntheticVehiclePlane"
-                    }
-                }
-            },
-            "VehicleCar": {
-                "type": "object",
-                "properties": {
-                    "year": {
-                        "type": "integer",
-                        "format": "int32"
-                    },
-                    "model": {
-                        "type": "string"
-                    },
-                    "make": {
-                        "type": "string"
-                    }
-                }
-            },
-            "VehicleMixin": {
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "type"
-                ]
-            },
-            "VehiclePlane": {
-                "type": "object",
-                "properties": {
-                    "model": {
-                        "type": "string"
-                    }
-                }
+            "required": true
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
             }
+          },
+          {
+            "name": "whenThree",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "whenFour",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "format": "epoch-seconds"
+            }
+          },
+          {
+            "name": "X-Bamtech-Partner",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "when",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "format": "http-date"
+            }
+          },
+          {
+            "name": "whenAlso",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "format": "http-date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Greet200response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GreetOutputPayload"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404Response",
+            "headers": {
+              "x-error-one": {
+                "schema": {
+                  "type": "string"
+                },
+                "required": true
+              }
+            }
+          },
+          "500": {
+            "description": "GeneralServerError500response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralServerErrorResponseContent"
+                }
+              }
+            }
+          }
         }
+      }
     },
-    "externalDocs": {
-        "description": "APIHomepage",
-        "url": "https://www.example.com/"
+    "/test_errors": {
+      "post": {
+        "operationId": "TestErrorsInExamples",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestErrorsInExamplesRequestContent"
+              },
+              "examples": {
+                "ONE": {
+                  "value": {
+                    "in": "testinput"
+                  }
+                },
+                "THREE": {
+                  "value": {
+                    "in": "testinputthree"
+                  }
+                },
+                "TWO": {
+                  "value": {
+                    "in": "testinputtwo"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "TestErrorsInExamples200response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestErrorsInExamplesResponseContent"
+                },
+                "examples": {
+                  "ONE": {
+                    "value": {
+                      "out": "testoutput"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404Response",
+            "headers": {
+              "x-one": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "x-three": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "x-two": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/NotFoundResponseContent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/NotFoundTwoResponseContent"
+                    }
+                  ]
+                },
+                "examples": {
+                  "THREE": {
+                    "value": {
+                      "messageTwo": "Notfoundmessagetwo"
+                    }
+                  },
+                  "TWO": {
+                    "value": {
+                      "message": "Notfoundmessage"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "GeneralServerError500response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralServerErrorResponseContent"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/values": {
+      "get": {
+        "operationId": "GetValues",
+        "responses": {
+          "200": {
+            "description": "GetValues200response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetValuesResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "GeneralServerError500response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeneralServerErrorResponseContent"
+                }
+              }
+            }
+          }
+        }
+      }
     }
+  },
+  "components": {
+    "schemas": {
+      "Cat": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "example": {
+          "name": "Meow"
+        }
+      },
+      "CatOrDog": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/CatOrDogCat"
+          },
+          {
+            "$ref": "#/components/schemas/CatOrDogDog"
+          }
+        ],
+        "externalDocs": {
+          "description": "Homepage",
+          "url": "https://www.example.com/"
+        },
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "cat": "#/components/schemas/CatOrDogCat",
+            "dog": "#/components/schemas/CatOrDogDog"
+          }
+        }
+      },
+      "CatOrDogCat": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Cat"
+          },
+          {
+            "$ref": "#/components/schemas/CatOrDogMixin"
+          }
+        ]
+      },
+      "CatOrDogDog": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Dog"
+          },
+          {
+            "$ref": "#/components/schemas/CatOrDogMixin"
+          }
+        ]
+      },
+      "CatOrDogMixin": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "CatOrDogOpen": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "cat",
+            "properties": {
+              "cat": {
+                "$ref": "#/components/schemas/Cat"
+              }
+            },
+            "required": [
+              "cat"
+            ]
+          },
+          {
+            "type": "object",
+            "title": "dog",
+            "properties": {
+              "dog": {
+                "$ref": "#/components/schemas/Dog"
+              }
+            },
+            "required": [
+              "dog"
+            ]
+          },
+          {
+            "type": "object",
+            "additionalProperties": true,
+            "title": "other"
+          }
+        ]
+      },
+      "CatOrDogOpenDiscriminated": {
+        "oneOf": [
+          {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedCat"
+              },
+              {
+                "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedDog"
+              }
+            ],
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "cat": "#/components/schemas/CatOrDogOpenDiscriminatedCat",
+                "dog": "#/components/schemas/CatOrDogOpenDiscriminatedDog"
+              }
+            }
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
+              },
+              {
+                "additionalProperties": true
+              }
+            ]
+          }
+        ]
+      },
+      "CatOrDogOpenDiscriminatedCat": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Cat"
+          },
+          {
+            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
+          }
+        ]
+      },
+      "CatOrDogOpenDiscriminatedDog": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Dog"
+          },
+          {
+            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
+          }
+        ]
+      },
+      "CatOrDogOpenDiscriminatedMixin": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "Dog": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "breed": {
+            "type": "string"
+          }
+        },
+        "example": {
+          "name": "Woof"
+        }
+      },
+      "DoubleOrFloat": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "float",
+            "properties": {
+              "float": {
+                "type": "number",
+                "format": "float"
+              }
+            },
+            "required": [
+              "float"
+            ]
+          },
+          {
+            "type": "object",
+            "title": "double",
+            "properties": {
+              "double": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": [
+              "double"
+            ]
+          }
+        ]
+      },
+      "GeneralServerErrorResponseContent": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        }
+      },
+      "GetUnionResponseContent": {
+        "type": "object",
+        "properties": {
+          "intOrString": {
+            "$ref": "#/components/schemas/IntOrString"
+          },
+          "doubleOrFloat": {
+            "$ref": "#/components/schemas/DoubleOrFloat"
+          },
+          "catOrDog": {
+            "$ref": "#/components/schemas/CatOrDog"
+          },
+          "catOrDogOpen": {
+            "$ref": "#/components/schemas/CatOrDogOpen"
+          },
+          "catOrDogOpenDiscriminated": {
+            "$ref": "#/components/schemas/CatOrDogOpenDiscriminated"
+          }
+        }
+      },
+      "GetValuesResponseContent": {
+        "type": "object",
+        "properties": {
+          "values": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SomeValue"
+            }
+          }
+        },
+        "example": {
+          "values": []
+        }
+      },
+      "GreetOutputPayload": {
+        "type": "string"
+      },
+      "IntOrString": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "int",
+            "properties": {
+              "int": {
+                "type": "integer",
+                "format": "int32"
+              }
+            },
+            "required": [
+              "int"
+            ]
+          },
+          {
+            "type": "object",
+            "title": "string",
+            "properties": {
+              "string": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "string"
+            ]
+          }
+        ]
+      },
+      "NotFoundResponseContent": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      },
+      "NotFoundTwoResponseContent": {
+        "type": "object",
+        "properties": {
+          "messageTwo": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "messageTwo"
+        ]
+      },
+      "SomeValue": {
+        "oneOf": [
+          {
+            "type": "string",
+            "title": "message"
+          },
+          {
+            "type": "integer",
+            "title": "value",
+            "format": "int32"
+          }
+        ]
+      },
+      "TestErrorsInExamplesRequestContent": {
+        "type": "object",
+        "properties": {
+          "in": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "in"
+        ]
+      },
+      "TestErrorsInExamplesResponseContent": {
+        "type": "object",
+        "properties": {
+          "out": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "out"
+        ]
+      }
+    }
+  },
+  "externalDocs": {
+    "description": "APIHomepage",
+    "url": "https://www.example.com/"
+  }
 }

--- a/modules/openapi/test/resources/foo.json
+++ b/modules/openapi/test/resources/foo.json
@@ -1,625 +1,699 @@
 {
-  "openapi": "3.0.2",
-  "info": {
-    "title": "HelloWorldService",
-    "version": "0.0.1"
-  },
-  "paths": {
-    "/default": {
-      "get": {
-        "operationId": "GetUnion",
-        "responses": {
-          "200": {
-            "description": "GetUnion200response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetUnionResponseContent"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "GeneralServerError500response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GeneralServerErrorResponseContent"
-                }
-              }
-            }
-          }
-        }
-      }
+    "openapi": "3.0.2",
+    "info": {
+        "title": "HelloWorldService",
+        "version": "0.0.1"
     },
-    "/hello/{name}/{ts}": {
-      "get": {
-        "externalDocs": {
-          "description": "APIHomepage2",
-          "url": "https://www.example2.com/"
-        },
-        "operationId": "Greet",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "path",
-            "schema": {
-              "type": "string"
-            },
-            "required": true
-          },
-          {
-            "name": "ts",
-            "in": "path",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "required": true
-          },
-          {
-            "name": "from",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          },
-          {
-            "name": "whenThree",
-            "in": "header",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          },
-          {
-            "name": "whenFour",
-            "in": "header",
-            "schema": {
-              "type": "string",
-              "format": "epoch-seconds"
-            }
-          },
-          {
-            "name": "X-Bamtech-Partner",
-            "in": "header",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "when",
-            "in": "header",
-            "schema": {
-              "type": "string",
-              "format": "http-date"
-            }
-          },
-          {
-            "name": "whenAlso",
-            "in": "header",
-            "schema": {
-              "type": "string",
-              "format": "http-date"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Greet200response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GreetOutputPayload"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "404Response",
-            "headers": {
-              "x-error-one": {
-                "schema": {
-                  "type": "string"
-                },
-                "required": true
-              }
-            }
-          },
-          "500": {
-            "description": "GeneralServerError500response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GeneralServerErrorResponseContent"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/test_errors": {
-      "post": {
-        "operationId": "TestErrorsInExamples",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TestErrorsInExamplesRequestContent"
-              },
-              "examples": {
-                "ONE": {
-                  "value": {
-                    "in": "testinput"
-                  }
-                },
-                "THREE": {
-                  "value": {
-                    "in": "testinputthree"
-                  }
-                },
-                "TWO": {
-                  "value": {
-                    "in": "testinputtwo"
-                  }
-                }
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "TestErrorsInExamples200response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TestErrorsInExamplesResponseContent"
-                },
-                "examples": {
-                  "ONE": {
-                    "value": {
-                      "out": "testoutput"
+    "paths": {
+        "/default": {
+            "get": {
+                "operationId": "GetUnion",
+                "responses": {
+                    "200": {
+                        "description": "GetUnion200response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetUnionResponseContent"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "GeneralServerError500response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GeneralServerErrorResponseContent"
+                                }
+                            }
+                        }
                     }
-                  }
                 }
-              }
             }
-          },
-          "404": {
-            "description": "404Response",
-            "headers": {
-              "x-one": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "x-three": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "x-two": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "oneOf": [
+        },
+        "/hello/{name}/{ts}": {
+            "get": {
+                "externalDocs": {
+                    "description": "APIHomepage2",
+                    "url": "https://www.example2.com/"
+                },
+                "operationId": "Greet",
+                "parameters": [
                     {
-                      "$ref": "#/components/schemas/NotFoundResponseContent"
+                        "name": "name",
+                        "in": "path",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": true
                     },
                     {
-                      "$ref": "#/components/schemas/NotFoundTwoResponseContent"
+                        "name": "ts",
+                        "in": "path",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "required": true
+                    },
+                    {
+                        "name": "from",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "name": "whenThree",
+                        "in": "header",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "name": "whenFour",
+                        "in": "header",
+                        "schema": {
+                            "type": "string",
+                            "format": "epoch-seconds"
+                        }
+                    },
+                    {
+                        "name": "X-Bamtech-Partner",
+                        "in": "header",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "when",
+                        "in": "header",
+                        "schema": {
+                            "type": "string",
+                            "format": "http-date"
+                        }
+                    },
+                    {
+                        "name": "whenAlso",
+                        "in": "header",
+                        "schema": {
+                            "type": "string",
+                            "format": "http-date"
+                        }
                     }
-                  ]
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Greet200response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GreetOutputPayload"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "404Response",
+                        "headers": {
+                            "x-error-one": {
+                                "schema": {
+                                    "type": "string"
+                                },
+                                "required": true
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "GeneralServerError500response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GeneralServerErrorResponseContent"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/test_errors": {
+            "post": {
+                "operationId": "TestErrorsInExamples",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TestErrorsInExamplesRequestContent"
+                            },
+                            "examples": {
+                                "ONE": {
+                                    "value": {
+                                        "in": "testinput"
+                                    }
+                                },
+                                "THREE": {
+                                    "value": {
+                                        "in": "testinputthree"
+                                    }
+                                },
+                                "TWO": {
+                                    "value": {
+                                        "in": "testinputtwo"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": true
                 },
-                "examples": {
-                  "THREE": {
-                    "value": {
-                      "messageTwo": "Notfoundmessagetwo"
+                "responses": {
+                    "200": {
+                        "description": "TestErrorsInExamples200response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TestErrorsInExamplesResponseContent"
+                                },
+                                "examples": {
+                                    "ONE": {
+                                        "value": {
+                                            "out": "testoutput"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "404Response",
+                        "headers": {
+                            "x-one": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "x-three": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "x-two": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/NotFoundResponseContent"
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/NotFoundTwoResponseContent"
+                                        }
+                                    ]
+                                },
+                                "examples": {
+                                    "THREE": {
+                                        "value": {
+                                            "messageTwo": "Notfoundmessagetwo"
+                                        }
+                                    },
+                                    "TWO": {
+                                        "value": {
+                                            "message": "Notfoundmessage"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "GeneralServerError500response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GeneralServerErrorResponseContent"
+                                }
+                            }
+                        }
                     }
-                  },
-                  "TWO": {
-                    "value": {
-                      "message": "Notfoundmessage"
+                }
+            }
+        },
+        "/values": {
+            "get": {
+                "operationId": "GetValues",
+                "responses": {
+                    "200": {
+                        "description": "GetValues200response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetValuesResponseContent"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "GeneralServerError500response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GeneralServerErrorResponseContent"
+                                }
+                            }
+                        }
                     }
-                  }
                 }
-              }
             }
-          },
-          "500": {
-            "description": "GeneralServerError500response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GeneralServerErrorResponseContent"
-                }
-              }
-            }
-          }
         }
-      }
     },
-    "/values": {
-      "get": {
-        "operationId": "GetValues",
-        "responses": {
-          "200": {
-            "description": "GetValues200response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetValuesResponseContent"
+    "components": {
+        "schemas": {
+            "Cat": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "example": {
+                    "name": "Meow"
                 }
-              }
-            }
-          },
-          "500": {
-            "description": "GeneralServerError500response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GeneralServerErrorResponseContent"
+            },
+            "CatOrDog": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/SyntheticCatOrDogCat"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SyntheticCatOrDogDog"
+                    }
+                ],
+                "externalDocs": {
+                    "description": "Homepage",
+                    "url": "https://www.example.com/"
+                },
+                "discriminator": {
+                    "propertyName": "type",
+                    "mapping": {
+                        "cat": "#/components/schemas/SyntheticCatOrDogCat",
+                        "dog": "#/components/schemas/SyntheticCatOrDogDog"
+                    }
                 }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "Cat": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          }
-        },
-        "example": {
-          "name": "Meow"
-        }
-      },
-      "CatOrDog": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CatOrDogCat"
-          },
-          {
-            "$ref": "#/components/schemas/CatOrDogDog"
-          }
-        ],
-        "externalDocs": {
-          "description": "Homepage",
-          "url": "https://www.example.com/"
-        },
-        "discriminator": {
-          "propertyName": "type",
-          "mapping": {
-            "cat": "#/components/schemas/CatOrDogCat",
-            "dog": "#/components/schemas/CatOrDogDog"
-          }
-        }
-      },
-      "CatOrDogCat": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Cat"
-          },
-          {
-            "$ref": "#/components/schemas/CatOrDogMixin"
-          }
-        ]
-      },
-      "CatOrDogDog": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Dog"
-          },
-          {
-            "$ref": "#/components/schemas/CatOrDogMixin"
-          }
-        ]
-      },
-      "CatOrDogMixin": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type"
-        ]
-      },
-      "CatOrDogOpen": {
-        "oneOf": [
-          {
-            "type": "object",
-            "title": "cat",
-            "properties": {
-              "cat": {
-                "$ref": "#/components/schemas/Cat"
-              }
             },
-            "required": [
-              "cat"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "dog",
-            "properties": {
-              "dog": {
-                "$ref": "#/components/schemas/Dog"
-              }
+            "CatOrDogMixin": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "type"
+                ]
             },
-            "required": [
-              "dog"
-            ]
-          },
-          {
-            "type": "object",
-            "additionalProperties": true,
-            "title": "other"
-          }
-        ]
-      },
-      "CatOrDogOpenDiscriminated": {
-        "oneOf": [
-          {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedCat"
-              },
-              {
-                "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedDog"
-              }
-            ],
-            "discriminator": {
-              "propertyName": "type",
-              "mapping": {
-                "cat": "#/components/schemas/CatOrDogOpenDiscriminatedCat",
-                "dog": "#/components/schemas/CatOrDogOpenDiscriminatedDog"
-              }
-            }
-          },
-          {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
-              },
-              {
-                "additionalProperties": true
-              }
-            ]
-          }
-        ]
-      },
-      "CatOrDogOpenDiscriminatedCat": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Cat"
-          },
-          {
-            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
-          }
-        ]
-      },
-      "CatOrDogOpenDiscriminatedDog": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Dog"
-          },
-          {
-            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
-          }
-        ]
-      },
-      "CatOrDogOpenDiscriminatedMixin": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type"
-        ]
-      },
-      "Dog": {
-        "type": "object",
-        "additionalProperties": true,
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "breed": {
-            "type": "string"
-          }
-        },
-        "example": {
-          "name": "Woof"
-        }
-      },
-      "DoubleOrFloat": {
-        "oneOf": [
-          {
-            "type": "object",
-            "title": "float",
-            "properties": {
-              "float": {
-                "type": "number",
-                "format": "float"
-              }
+            "CatOrDogOpen": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "title": "cat",
+                        "properties": {
+                            "cat": {
+                                "$ref": "#/components/schemas/Cat"
+                            }
+                        },
+                        "required": [
+                            "cat"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "dog",
+                        "properties": {
+                            "dog": {
+                                "$ref": "#/components/schemas/Dog"
+                            }
+                        },
+                        "required": [
+                            "dog"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "title": "other"
+                    }
+                ]
             },
-            "required": [
-              "float"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "double",
-            "properties": {
-              "double": {
-                "type": "number",
-                "format": "double"
-              }
+            "CatOrDogOpenDiscriminated": {
+                "oneOf": [
+                    {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/SyntheticCatOrDogOpenDiscriminatedCat"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SyntheticCatOrDogOpenDiscriminatedDog"
+                            }
+                        ],
+                        "discriminator": {
+                            "propertyName": "type",
+                            "mapping": {
+                                "cat": "#/components/schemas/SyntheticCatOrDogOpenDiscriminatedCat",
+                                "dog": "#/components/schemas/SyntheticCatOrDogOpenDiscriminatedDog"
+                            }
+                        }
+                    },
+                    {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
+                            },
+                            {
+                                "additionalProperties": true
+                            }
+                        ]
+                    }
+                ]
             },
-            "required": [
-              "double"
-            ]
-          }
-        ]
-      },
-      "GeneralServerErrorResponseContent": {
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          },
-          "count": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          }
-        }
-      },
-      "GetUnionResponseContent": {
-        "type": "object",
-        "properties": {
-          "intOrString": {
-            "$ref": "#/components/schemas/IntOrString"
-          },
-          "doubleOrFloat": {
-            "$ref": "#/components/schemas/DoubleOrFloat"
-          },
-          "catOrDog": {
-            "$ref": "#/components/schemas/CatOrDog"
-          },
-          "catOrDogOpen": {
-            "$ref": "#/components/schemas/CatOrDogOpen"
-          },
-          "catOrDogOpenDiscriminated": {
-            "$ref": "#/components/schemas/CatOrDogOpenDiscriminated"
-          }
-        }
-      },
-      "GetValuesResponseContent": {
-        "type": "object",
-        "properties": {
-          "values": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SomeValue"
-            }
-          }
-        },
-        "example": {
-          "values": []
-        }
-      },
-      "GreetOutputPayload": {
-        "type": "string"
-      },
-      "IntOrString": {
-        "oneOf": [
-          {
-            "type": "object",
-            "title": "int",
-            "properties": {
-              "int": {
-                "type": "integer",
-                "format": "int32"
-              }
+            "CatOrDogOpenDiscriminatedMixin": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "type"
+                ]
             },
-            "required": [
-              "int"
-            ]
-          },
-          {
-            "type": "object",
-            "title": "string",
-            "properties": {
-              "string": {
+            "Dog": {
+                "type": "object",
+                "additionalProperties": true,
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "breed": {
+                        "type": "string"
+                    }
+                },
+                "example": {
+                    "name": "Woof"
+                }
+            },
+            "DoubleOrFloat": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "title": "float",
+                        "properties": {
+                            "float": {
+                                "type": "number",
+                                "format": "float"
+                            }
+                        },
+                        "required": [
+                            "float"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "double",
+                        "properties": {
+                            "double": {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        },
+                        "required": [
+                            "double"
+                        ]
+                    }
+                ]
+            },
+            "GeneralServerErrorResponseContent": {
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    },
+                    "count": {
+                        "type": "integer",
+                        "format": "int32",
+                        "nullable": true
+                    }
+                }
+            },
+            "GetUnionResponseContent": {
+                "type": "object",
+                "properties": {
+                    "intOrString": {
+                        "$ref": "#/components/schemas/IntOrString"
+                    },
+                    "doubleOrFloat": {
+                        "$ref": "#/components/schemas/DoubleOrFloat"
+                    },
+                    "catOrDog": {
+                        "$ref": "#/components/schemas/CatOrDog"
+                    },
+                    "catOrDogOpen": {
+                        "$ref": "#/components/schemas/CatOrDogOpen"
+                    },
+                    "catOrDogOpenDiscriminated": {
+                        "$ref": "#/components/schemas/CatOrDogOpenDiscriminated"
+                    },
+                    "vehicle": {
+                        "$ref": "#/components/schemas/Vehicle"
+                    }
+                }
+            },
+            "GetValuesResponseContent": {
+                "type": "object",
+                "properties": {
+                    "values": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SomeValue"
+                        }
+                    }
+                },
+                "example": {
+                    "values": []
+                }
+            },
+            "GreetOutputPayload": {
                 "type": "string"
-              }
             },
-            "required": [
-              "string"
-            ]
-          }
-        ]
-      },
-      "NotFoundResponseContent": {
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "message"
-        ]
-      },
-      "NotFoundTwoResponseContent": {
-        "type": "object",
-        "properties": {
-          "messageTwo": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "messageTwo"
-        ]
-      },
-      "SomeValue": {
-        "oneOf": [
-          {
-            "type": "string",
-            "title": "message"
-          },
-          {
-            "type": "integer",
-            "title": "value",
-            "format": "int32"
-          }
-        ]
-      },
-      "TestErrorsInExamplesRequestContent": {
-        "type": "object",
-        "properties": {
-          "in": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "in"
-        ]
-      },
-      "TestErrorsInExamplesResponseContent": {
-        "type": "object",
-        "properties": {
-          "out": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "out"
-        ]
-      }
+            "IntOrString": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "title": "int",
+                        "properties": {
+                            "int": {
+                                "type": "integer",
+                                "format": "int32"
+                            }
+                        },
+                        "required": [
+                            "int"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "title": "string",
+                        "properties": {
+                            "string": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "string"
+                        ]
+                    }
+                ]
+            },
+            "NotFoundResponseContent": {
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "message"
+                ]
+            },
+            "NotFoundTwoResponseContent": {
+                "type": "object",
+                "properties": {
+                    "messageTwo": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "messageTwo"
+                ]
+            },
+            "SomeValue": {
+                "oneOf": [
+                    {
+                        "type": "string",
+                        "title": "message"
+                    },
+                    {
+                        "type": "integer",
+                        "title": "value",
+                        "format": "int32"
+                    }
+                ]
+            },
+            "SyntheticCatOrDogCat": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Cat"
+                    },
+                    {
+                        "$ref": "#/components/schemas/CatOrDogMixin"
+                    }
+                ]
+            },
+            "SyntheticCatOrDogDog": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Dog"
+                    },
+                    {
+                        "$ref": "#/components/schemas/CatOrDogMixin"
+                    }
+                ]
+            },
+            "SyntheticCatOrDogOpenDiscriminatedCat": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Cat"
+                    },
+                    {
+                        "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
+                    }
+                ]
+            },
+            "SyntheticCatOrDogOpenDiscriminatedDog": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Dog"
+                    },
+                    {
+                        "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
+                    }
+                ]
+            },
+            "SyntheticVehicleCar": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/VehicleCar"
+                    },
+                    {
+                        "$ref": "#/components/schemas/VehicleMixin"
+                    }
+                ]
+            },
+            "SyntheticVehiclePlane": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/VehiclePlane"
+                    },
+                    {
+                        "$ref": "#/components/schemas/VehicleMixin"
+                    }
+                ]
+            },
+            "TestErrorsInExamplesRequestContent": {
+                "type": "object",
+                "properties": {
+                    "in": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "in"
+                ]
+            },
+            "TestErrorsInExamplesResponseContent": {
+                "type": "object",
+                "properties": {
+                    "out": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "out"
+                ]
+            },
+            "Vehicle": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/SyntheticVehicleCar"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SyntheticVehiclePlane"
+                    }
+                ],
+                "discriminator": {
+                    "propertyName": "type",
+                    "mapping": {
+                        "car": "#/components/schemas/SyntheticVehicleCar",
+                        "plane": "#/components/schemas/SyntheticVehiclePlane"
+                    }
+                }
+            },
+            "VehicleCar": {
+                "type": "object",
+                "properties": {
+                    "year": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "model": {
+                        "type": "string"
+                    },
+                    "make": {
+                        "type": "string"
+                    }
+                }
+            },
+            "VehicleMixin": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "type"
+                ]
+            },
+            "VehiclePlane": {
+                "type": "object",
+                "properties": {
+                    "model": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    },
+    "externalDocs": {
+        "description": "APIHomepage",
+        "url": "https://www.example.com/"
     }
-  },
-  "externalDocs": {
-    "description": "APIHomepage",
-    "url": "https://www.example.com/"
-  }
 }

--- a/modules/openapi/test/resources/foo.json
+++ b/modules/openapi/test/resources/foo.json
@@ -291,10 +291,10 @@
       "CatOrDog": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/CatOrDogCat"
+            "$ref": "#/components/schemas/SyntheticCatOrDogCat"
           },
           {
-            "$ref": "#/components/schemas/CatOrDogDog"
+            "$ref": "#/components/schemas/SyntheticCatOrDogDog"
           }
         ],
         "externalDocs": {
@@ -304,30 +304,10 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "cat": "#/components/schemas/CatOrDogCat",
-            "dog": "#/components/schemas/CatOrDogDog"
+            "cat": "#/components/schemas/SyntheticCatOrDogCat",
+            "dog": "#/components/schemas/SyntheticCatOrDogDog"
           }
         }
-      },
-      "CatOrDogCat": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Cat"
-          },
-          {
-            "$ref": "#/components/schemas/CatOrDogMixin"
-          }
-        ]
-      },
-      "CatOrDogDog": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Dog"
-          },
-          {
-            "$ref": "#/components/schemas/CatOrDogMixin"
-          }
-        ]
       },
       "CatOrDogMixin": {
         "type": "object",
@@ -378,17 +358,17 @@
           {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedCat"
+                "$ref": "#/components/schemas/SyntheticCatOrDogOpenDiscriminatedCat"
               },
               {
-                "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedDog"
+                "$ref": "#/components/schemas/SyntheticCatOrDogOpenDiscriminatedDog"
               }
             ],
             "discriminator": {
               "propertyName": "type",
               "mapping": {
-                "cat": "#/components/schemas/CatOrDogOpenDiscriminatedCat",
-                "dog": "#/components/schemas/CatOrDogOpenDiscriminatedDog"
+                "cat": "#/components/schemas/SyntheticCatOrDogOpenDiscriminatedCat",
+                "dog": "#/components/schemas/SyntheticCatOrDogOpenDiscriminatedDog"
               }
             }
           },
@@ -401,26 +381,6 @@
                 "additionalProperties": true
               }
             ]
-          }
-        ]
-      },
-      "CatOrDogOpenDiscriminatedCat": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Cat"
-          },
-          {
-            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
-          }
-        ]
-      },
-      "CatOrDogOpenDiscriminatedDog": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Dog"
-          },
-          {
-            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
           }
         ]
       },
@@ -510,6 +470,9 @@
           },
           "catOrDogOpenDiscriminated": {
             "$ref": "#/components/schemas/CatOrDogOpenDiscriminated"
+          },
+          "vehicle": {
+            "$ref": "#/components/schemas/Vehicle"
           }
         }
       },
@@ -594,6 +557,66 @@
           }
         ]
       },
+      "SyntheticCatOrDogCat": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Cat"
+          },
+          {
+            "$ref": "#/components/schemas/CatOrDogMixin"
+          }
+        ]
+      },
+      "SyntheticCatOrDogDog": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Dog"
+          },
+          {
+            "$ref": "#/components/schemas/CatOrDogMixin"
+          }
+        ]
+      },
+      "SyntheticCatOrDogOpenDiscriminatedCat": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Cat"
+          },
+          {
+            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
+          }
+        ]
+      },
+      "SyntheticCatOrDogOpenDiscriminatedDog": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Dog"
+          },
+          {
+            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
+          }
+        ]
+      },
+      "SyntheticVehicleCar": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VehicleCar"
+          },
+          {
+            "$ref": "#/components/schemas/VehicleMixin"
+          }
+        ]
+      },
+      "SyntheticVehiclePlane": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VehiclePlane"
+          },
+          {
+            "$ref": "#/components/schemas/VehicleMixin"
+          }
+        ]
+      },
       "TestErrorsInExamplesRequestContent": {
         "type": "object",
         "properties": {
@@ -615,6 +638,57 @@
         "required": [
           "out"
         ]
+      },
+      "Vehicle": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SyntheticVehicleCar"
+          },
+          {
+            "$ref": "#/components/schemas/SyntheticVehiclePlane"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "car": "#/components/schemas/SyntheticVehicleCar",
+            "plane": "#/components/schemas/SyntheticVehiclePlane"
+          }
+        }
+      },
+      "VehicleCar": {
+        "type": "object",
+        "properties": {
+          "year": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "model": {
+            "type": "string"
+          },
+          "make": {
+            "type": "string"
+          }
+        }
+      },
+      "VehicleMixin": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "VehiclePlane": {
+        "type": "object",
+        "properties": {
+          "model": {
+            "type": "string"
+          }
+        }
       }
     }
   },

--- a/modules/openapi/test/resources/foo.json
+++ b/modules/openapi/test/resources/foo.json
@@ -291,10 +291,10 @@
       "CatOrDog": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/SyntheticCatOrDogCat"
+            "$ref": "#/components/schemas/CatOrDogCat"
           },
           {
-            "$ref": "#/components/schemas/SyntheticCatOrDogDog"
+            "$ref": "#/components/schemas/CatOrDogDog"
           }
         ],
         "externalDocs": {
@@ -304,10 +304,30 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "cat": "#/components/schemas/SyntheticCatOrDogCat",
-            "dog": "#/components/schemas/SyntheticCatOrDogDog"
+            "cat": "#/components/schemas/CatOrDogCat",
+            "dog": "#/components/schemas/CatOrDogDog"
           }
         }
+      },
+      "CatOrDogCat": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Cat"
+          },
+          {
+            "$ref": "#/components/schemas/CatOrDogMixin"
+          }
+        ]
+      },
+      "CatOrDogDog": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Dog"
+          },
+          {
+            "$ref": "#/components/schemas/CatOrDogMixin"
+          }
+        ]
       },
       "CatOrDogMixin": {
         "type": "object",
@@ -358,17 +378,17 @@
           {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/SyntheticCatOrDogOpenDiscriminatedCat"
+                "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedCat"
               },
               {
-                "$ref": "#/components/schemas/SyntheticCatOrDogOpenDiscriminatedDog"
+                "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedDog"
               }
             ],
             "discriminator": {
               "propertyName": "type",
               "mapping": {
-                "cat": "#/components/schemas/SyntheticCatOrDogOpenDiscriminatedCat",
-                "dog": "#/components/schemas/SyntheticCatOrDogOpenDiscriminatedDog"
+                "cat": "#/components/schemas/CatOrDogOpenDiscriminatedCat",
+                "dog": "#/components/schemas/CatOrDogOpenDiscriminatedDog"
               }
             }
           },
@@ -381,6 +401,26 @@
                 "additionalProperties": true
               }
             ]
+          }
+        ]
+      },
+      "CatOrDogOpenDiscriminatedCat": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Cat"
+          },
+          {
+            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
+          }
+        ]
+      },
+      "CatOrDogOpenDiscriminatedDog": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Dog"
+          },
+          {
+            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
           }
         ]
       },
@@ -557,66 +597,6 @@
           }
         ]
       },
-      "SyntheticCatOrDogCat": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Cat"
-          },
-          {
-            "$ref": "#/components/schemas/CatOrDogMixin"
-          }
-        ]
-      },
-      "SyntheticCatOrDogDog": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Dog"
-          },
-          {
-            "$ref": "#/components/schemas/CatOrDogMixin"
-          }
-        ]
-      },
-      "SyntheticCatOrDogOpenDiscriminatedCat": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Cat"
-          },
-          {
-            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
-          }
-        ]
-      },
-      "SyntheticCatOrDogOpenDiscriminatedDog": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/Dog"
-          },
-          {
-            "$ref": "#/components/schemas/CatOrDogOpenDiscriminatedMixin"
-          }
-        ]
-      },
-      "SyntheticVehicleCar": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/VehicleCar"
-          },
-          {
-            "$ref": "#/components/schemas/VehicleMixin"
-          }
-        ]
-      },
-      "SyntheticVehiclePlane": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/VehiclePlane"
-          },
-          {
-            "$ref": "#/components/schemas/VehicleMixin"
-          }
-        ]
-      },
       "TestErrorsInExamplesRequestContent": {
         "type": "object",
         "properties": {
@@ -642,17 +622,17 @@
       "Vehicle": {
         "oneOf": [
           {
-            "$ref": "#/components/schemas/SyntheticVehicleCar"
+            "$ref": "#/components/schemas/VehicleCarCase"
           },
           {
-            "$ref": "#/components/schemas/SyntheticVehiclePlane"
+            "$ref": "#/components/schemas/VehiclePlaneCase"
           }
         ],
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "car": "#/components/schemas/SyntheticVehicleCar",
-            "plane": "#/components/schemas/SyntheticVehiclePlane"
+            "car": "#/components/schemas/VehicleCarCase",
+            "plane": "#/components/schemas/VehiclePlaneCase"
           }
         }
       },
@@ -670,6 +650,16 @@
             "type": "string"
           }
         }
+      },
+      "VehicleCarCase": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VehicleCar"
+          },
+          {
+            "$ref": "#/components/schemas/VehicleMixin"
+          }
+        ]
       },
       "VehicleMixin": {
         "type": "object",
@@ -689,6 +679,16 @@
             "type": "string"
           }
         }
+      },
+      "VehiclePlaneCase": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/VehiclePlane"
+          },
+          {
+            "$ref": "#/components/schemas/VehicleMixin"
+          }
+        ]
       }
     }
   },

--- a/modules/openapi/test/resources/foo.smithy
+++ b/modules/openapi/test/resources/foo.smithy
@@ -181,6 +181,7 @@ structure GetUnionResponse {
     catOrDog: CatOrDog
     catOrDogOpen: CatOrDogOpen
     catOrDogOpenDiscriminated: CatOrDogOpenDiscriminated
+    vehicle: Vehicle
 }
 
 union IntOrString {
@@ -264,4 +265,20 @@ union CatOrDogOpenDiscriminated {
 
     @jsonUnknown
     other: Document
+}
+
+structure VehicleCar {
+    year: Integer
+    model: String
+    make: String
+}
+
+structure VehiclePlane {
+    model: String
+}
+
+@discriminated("type")
+union Vehicle {
+    car: VehicleCar
+    plane: VehiclePlane
 }


### PR DESCRIPTION
So given the following smithy schema

```smithy
structure VehicleCar {
    year: Integer
    model: String
    make: String
}

structure VehiclePlane {
    model: String
}

@discriminated("type")
union Vehicle {
    car: VehicleCar
    plane: VehiclePlane
}
```

The open api generator would generate a schema for each member of the union as `<UnionName><FieldName.capitalize>`. If that name matched the name of something that already exists, then the generated openApi spec would have an invalid self reference. This just adds "Synthetic" to the name of the generated schema in order to reduce conflicts with existing schemas. 

Note that this would fail if I were to name the structures as `SyntheticVehicleCar` and `SyntheticVehiclePlane`, but I want to open the conversation to see if having random characters in the name or something else is preferred. 