### PR TITLE
allow openApiExtensions trait to be sparse

### DIFF
--- a/modules/core/resources/META-INF/smithy/openapi/openapi.smithy
+++ b/modules/core/resources/META-INF/smithy/openapi/openapi.smithy
@@ -5,6 +5,7 @@ namespace alloy.openapi
 /// This traits allows the encoding of OpenAPI Extensions
 /// as defined in https://swagger.io/docs/specification/openapi-extensions/.
 @trait
+@sparse
 map openapiExtensions {
     key: String
     value: Document


### PR DESCRIPTION
In PR https://github.com/disneystreaming/smithy-translate/pull/263 a test is failing because there is a [null value in the openapiExtensions trait](https://github.com/disneystreaming/smithy-translate/blob/main/modules/openapi/tests/src/ExtensionsSpec.scala#L52). It seems that in the alloy version used before my PR and the version I've updated to smithy was also updated in which the @sparse trait was introduced to allow null values in maps.