### PR TITLE
Add protobuf definitions for time types

### DIFF
--- a/modules/core/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/modules/core/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -31,6 +31,10 @@ alloy.openapi.OpenApiExtensionsTrait$Provider
 alloy.openapi.SummaryTrait$Provider
 alloy.proto.GrpcTrait$Provider
 alloy.proto.ProtoCompactUUIDTrait$Provider
+alloy.proto.ProtoCompactLocalDateTrait$Provider
+alloy.proto.ProtoCompactMonthDayTrait$Provider
+alloy.proto.ProtoCompactOffsetDateTimeTrait$Provider
+alloy.proto.ProtoCompactYearMonthTrait$Provider
 alloy.proto.ProtoEnabledTrait$Provider
 alloy.proto.ProtoIndexTrait$Provider
 alloy.proto.ProtoInlinedOneOfTrait$Provider

--- a/modules/core/resources/META-INF/smithy/proto/proto.smithy
+++ b/modules/core/resources/META-INF/smithy/proto/proto.smithy
@@ -114,3 +114,31 @@ structure protoWrapped {}
     selector: ":test(string [trait|alloy#uuidFormat], member > string [trait|alloy#uuidFormat])"
 )
 structure protoCompactUUID {}
+
+// indicate that strings that have the @alloy#dateFormat applied or
+// referencing @alloy#LocalDate should use a proto message containing 3 ints for the year, month, day
+@trait(
+    selector: ":test(string [trait|alloy#dateFormat], member > string [trait|alloy#dateFormat])"
+)
+structure protoCompactLocalDate {}
+
+// indicate that strings that have the @alloy#yearMonthFormat applied or
+// referencing @alloy#YearMonth should use a proto message containing 2 ints for the year and month
+@trait(
+    selector: ":test(string [trait|alloy#yearMonthFormat], member > string [trait|alloy#yearMonthFormat])"
+)
+structure protoCompactYearMonth {}
+
+// indicate that strings that have the @alloy#monthDayFormat applied or
+// referencing @alloy#MonthDay should use a proto message containing 2 ints for the month and day
+@trait(
+    selector: ":test(string [trait|alloy#monthDayFormat], member > string [trait|alloy#monthDayFormat])"
+)
+structure protoCompactMonthDay {}
+
+// indicate that strings that have the @alloy#offsetDateTimeFormat applied or
+// referencing @alloy#OffsetDateTime should use a proto message containing 3 fields
+@trait(
+    selector: ":test(timestamp [trait|alloy#offsetDateTimeFormat], member > timestamp [trait|alloy#offsetDateTimeFormat])"
+)
+structure protoCompactOffsetDateTime {}

--- a/modules/core/resources/META-INF/smithy/proto/proto.smithy
+++ b/modules/core/resources/META-INF/smithy/proto/proto.smithy
@@ -111,34 +111,54 @@ structure protoWrapped {}
 // indicates that string abiding by @alloy#uuidFormat should
 // be encoded using a proto message containing 2 long values.
 @trait(
-    selector: ":test(string [trait|alloy#uuidFormat], member > string [trait|alloy#uuidFormat])"
+    selector: ":test(
+        string [trait|alloy#uuidFormat],
+        member > string [trait|alloy#uuidFormat],
+        member [trait|alloy#uuidFormat] > string
+    )"
 )
 structure protoCompactUUID {}
 
 // indicate that strings that have the @alloy#dateFormat applied or
 // referencing @alloy#LocalDate should use a proto message containing 3 ints for the year, month, day
 @trait(
-    selector: ":test(string [trait|alloy#dateFormat], member > string [trait|alloy#dateFormat])"
+    selector: ":test(
+        string [trait|alloy#dateFormat],
+        member > string [trait|alloy#dateFormat],
+        member [trait|alloy#dateFormat] > string
+    )"
 )
 structure protoCompactLocalDate {}
 
 // indicate that strings that have the @alloy#yearMonthFormat applied or
 // referencing @alloy#YearMonth should use a proto message containing 2 ints for the year and month
 @trait(
-    selector: ":test(string [trait|alloy#yearMonthFormat], member > string [trait|alloy#yearMonthFormat])"
+    selector: ":test(
+        string [trait|alloy#yearMonthFormat],
+        member > string [trait|alloy#yearMonthFormat],
+        member [trait|alloy#yearMonthFormat] > string
+    )"
 )
 structure protoCompactYearMonth {}
 
 // indicate that strings that have the @alloy#monthDayFormat applied or
 // referencing @alloy#MonthDay should use a proto message containing 2 ints for the month and day
 @trait(
-    selector: ":test(string [trait|alloy#monthDayFormat], member > string [trait|alloy#monthDayFormat])"
+    selector: ":test(
+        string [trait|alloy#monthDayFormat],
+        member > string [trait|alloy#monthDayFormat],
+        member [trait|alloy#monthDayFormat] > string
+    )"
 )
 structure protoCompactMonthDay {}
 
 // indicate that strings that have the @alloy#offsetDateTimeFormat applied or
 // referencing @alloy#OffsetDateTime should use a proto message containing 3 fields
 @trait(
-    selector: ":test(timestamp [trait|alloy#offsetDateTimeFormat], member > timestamp [trait|alloy#offsetDateTimeFormat])"
+    selector: ":test(
+        timestamp [trait|alloy#offsetDateTimeFormat],
+        member > timestamp [trait|alloy#offsetDateTimeFormat],
+        member [trait|alloy#offsetDateTimeFormat] > timestamp
+    )"
 )
 structure protoCompactOffsetDateTime {}

--- a/modules/core/src/alloy/proto/ProtoCompactLocalDateTrait.java
+++ b/modules/core/src/alloy/proto/ProtoCompactLocalDateTrait.java
@@ -1,0 +1,46 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.proto;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AnnotationTrait;
+import software.amazon.smithy.model.traits.AbstractTrait;
+
+public class ProtoCompactLocalDateTrait extends AnnotationTrait {
+
+	public static ShapeId ID = ShapeId.from("alloy.proto#protoCompactLocalDate");
+
+	public ProtoCompactLocalDateTrait(ObjectNode node) {
+		super(ID, node);
+	}
+
+	public ProtoCompactLocalDateTrait() {
+		super(ID, Node.objectNode());
+	}
+
+	public static final class Provider extends AbstractTrait.Provider {
+		public Provider() {
+			super(ID);
+		}
+
+		@Override
+		public ProtoCompactLocalDateTrait createTrait(ShapeId target, Node node) {
+			return new ProtoCompactLocalDateTrait(node.expectObjectNode());
+		}
+	}
+}

--- a/modules/core/src/alloy/proto/ProtoCompactMonthDayTrait.java
+++ b/modules/core/src/alloy/proto/ProtoCompactMonthDayTrait.java
@@ -1,0 +1,46 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.proto;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AnnotationTrait;
+import software.amazon.smithy.model.traits.AbstractTrait;
+
+public class ProtoCompactMonthDayTrait extends AnnotationTrait {
+
+	public static ShapeId ID = ShapeId.from("alloy.proto#protoCompactMonthDay");
+
+	public ProtoCompactMonthDayTrait(ObjectNode node) {
+		super(ID, node);
+	}
+
+	public ProtoCompactMonthDayTrait() {
+		super(ID, Node.objectNode());
+	}
+
+	public static final class Provider extends AbstractTrait.Provider {
+		public Provider() {
+			super(ID);
+		}
+
+		@Override
+		public ProtoCompactMonthDayTrait createTrait(ShapeId target, Node node) {
+			return new ProtoCompactMonthDayTrait(node.expectObjectNode());
+		}
+	}
+}

--- a/modules/core/src/alloy/proto/ProtoCompactOffsetDateTimeTrait.java
+++ b/modules/core/src/alloy/proto/ProtoCompactOffsetDateTimeTrait.java
@@ -1,0 +1,46 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.proto;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AnnotationTrait;
+import software.amazon.smithy.model.traits.AbstractTrait;
+
+public class ProtoCompactOffsetDateTimeTrait extends AnnotationTrait {
+
+	public static ShapeId ID = ShapeId.from("alloy.proto#protoCompactOffsetDateTime");
+
+	public ProtoCompactOffsetDateTimeTrait(ObjectNode node) {
+		super(ID, node);
+	}
+
+	public ProtoCompactOffsetDateTimeTrait() {
+		super(ID, Node.objectNode());
+	}
+
+	public static final class Provider extends AbstractTrait.Provider {
+		public Provider() {
+			super(ID);
+		}
+
+		@Override
+		public ProtoCompactOffsetDateTimeTrait createTrait(ShapeId target, Node node) {
+			return new ProtoCompactOffsetDateTimeTrait(node.expectObjectNode());
+		}
+	}
+}

--- a/modules/core/src/alloy/proto/ProtoCompactYearMonthTrait.java
+++ b/modules/core/src/alloy/proto/ProtoCompactYearMonthTrait.java
@@ -1,0 +1,46 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.proto;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AnnotationTrait;
+import software.amazon.smithy.model.traits.AbstractTrait;
+
+public class ProtoCompactYearMonthTrait extends AnnotationTrait {
+
+	public static ShapeId ID = ShapeId.from("alloy.proto#protoCompactYearMonth");
+
+	public ProtoCompactYearMonthTrait(ObjectNode node) {
+		super(ID, node);
+	}
+
+	public ProtoCompactYearMonthTrait() {
+		super(ID, Node.objectNode());
+	}
+
+	public static final class Provider extends AbstractTrait.Provider {
+		public Provider() {
+			super(ID);
+		}
+
+		@Override
+		public ProtoCompactYearMonthTrait createTrait(ShapeId target, Node node) {
+			return new ProtoCompactYearMonthTrait(node.expectObjectNode());
+		}
+	}
+}

--- a/modules/core/test/resources/META-INF/smithy/traits.smithy
+++ b/modules/core/test/resources/META-INF/smithy/traits.smithy
@@ -309,4 +309,11 @@ structure ProtoCompactStruct {
 
     @protoCompactOffsetDateTime
     offsetDateTime: OffsetDateTime
+
+    @protoCompactYearMonth
+    @yearMonthFormat 
+    yearMonth2: String
+
+    @protoCompactYearMonth
+    yearMonth3: MyYearMonth
 }

--- a/modules/core/test/resources/META-INF/smithy/traits.smithy
+++ b/modules/core/test/resources/META-INF/smithy/traits.smithy
@@ -31,6 +31,10 @@ use alloy.proto#protoInlinedOneOf
 use alloy.proto#protoNumType
 use alloy.proto#protoTimestampFormat
 use alloy.proto#protoCompactUUID
+use alloy.proto#protoCompactLocalDate
+use alloy.proto#protoCompactYearMonth
+use alloy.proto#protoCompactMonthDay
+use alloy.proto#protoCompactOffsetDateTime
 use alloy.proto#protoWrapped
 use alloy.proto#protoReservedFields
 use alloy#localTimeFormat
@@ -42,9 +46,18 @@ use alloy#zonedDateTimeFormat
 use alloy#yearFormat
 use alloy#yearMonthFormat
 use alloy#monthDayFormat
+use alloy#UUID
+use alloy#LocalDate
+use alloy#YearMonth
+use alloy#MonthDay
+use alloy#OffsetDateTime
 
 @dateFormat
 string MyDate
+
+@dateFormat
+@protoCompactLocalDate
+string MyCompactDate
 
 @emailFormat
 @protoWrapped
@@ -64,7 +77,7 @@ string HexColorCode
 
 @uuidFormat
 @protoCompactUUID
-string ID
+string MyUUID
 
 structure SomeStruct {
     @defaultValue("a")
@@ -247,6 +260,11 @@ string MyLocalDateTime
 @timestampFormat("date-time")
 timestamp MyOffsetDateTime
 
+@offsetDateTimeFormat
+@timestampFormat("date-time")
+@protoCompactOffsetDateTime
+timestamp MyCompactOffsetDateTime
+
 @offsetTimeFormat
 string MyOffsetTime
 
@@ -265,6 +283,30 @@ integer MyYear
 @yearMonthFormat
 string MyYearMonth
 
+@yearMonthFormat
+@protoCompactYearMonth
+string MyCompactYearMonth
+
 @monthDayFormat
 string MyMonthDay
 
+@monthDayFormat
+@protoCompactMonthDay
+string MyCompactMonthDay
+
+structure ProtoCompactStruct {
+    @protoCompactUUID
+    uuid: UUID
+
+    @protoCompactLocalDate
+    localDate: LocalDate
+
+    @protoCompactYearMonth
+    yearMonth: YearMonth
+
+    @protoCompactMonthDay
+    monthDay: MonthDay
+
+    @protoCompactOffsetDateTime
+    offsetDateTime: OffsetDateTime
+}

--- a/modules/protobuf/resources/alloy/protobuf/types.proto
+++ b/modules/protobuf/resources/alloy/protobuf/types.proto
@@ -10,3 +10,52 @@ message CompactUUID {
 message EpochMillisTimestamp {
   int64 milliseconds = 1;
 }
+
+enum DayOfWeek {
+  DayOfWeek_UNSPECIFIED = 0;
+  DayOfWeek_MONDAY = 1;
+  DayOfWeek_TUESDAY = 2;
+  DayOfWeek_WEDNESDAY = 3;
+  DayOfWeek_THURSDAY = 4;
+  DayOfWeek_FRIDAY = 5;
+  DayOfWeek_SATURDAY = 6;
+  DayOfWeek_SUNDAY = 7;
+}
+
+enum Month {
+  Month_UNSPECIFIED = 0;
+  Month_JANUARY = 1;
+  Month_FEBRUARY = 2;
+  Month_MARCH = 3;
+  Month_APRIL = 4;
+  Month_MAY = 5;
+  Month_JUNE = 6;
+  Month_JULY = 7;
+  Month_AUGUST = 8;
+  Month_SEPTEMBER = 9;
+  Month_OCTOBER = 10;
+  Month_NOVEMBER = 11;
+  Month_DECEMBER = 12;
+}
+
+message CompactLocalDate {
+  uint32 year = 1;
+  uint32 month = 2;
+  uint32 day = 3;
+}
+
+message CompactYearMonth {
+  uint32 year = 1;
+  uint32 month = 2;
+}
+
+message CompactMonthDay {
+  uint32 month = 1;
+  uint32 day = 2;
+}
+
+message CompactOffsetDateTime {
+  int64 seconds = 1;
+  int32 nanos = 2;
+  string zone_offset = 3;
+}

--- a/modules/protobuf/resources/alloy/protobuf/wrappers.proto
+++ b/modules/protobuf/resources/alloy/protobuf/wrappers.proto
@@ -23,6 +23,22 @@ message CompactUUIDValue {
   alloy.protobuf.CompactUUID value = 1;
 }
 
+message CompactLocalDateValue {
+  alloy.protobuf.CompactLocalDate value = 1;
+}
+
+message CompactYearMonthValue {
+  alloy.protobuf.CompactYearMonth value = 1;
+}
+
+message CompactMonthDayValue {
+  alloy.protobuf.CompactMonthDay value = 1;
+}
+
+message CompactOffsetDateTimeValue {
+  alloy.protobuf.CompactOffsetDateTime value = 1;
+}
+
 message BigIntegerValue {
   string value = 1;
 }

--- a/modules/protobuf/resources/alloy/protobuf/wrappers.proto
+++ b/modules/protobuf/resources/alloy/protobuf/wrappers.proto
@@ -15,7 +15,6 @@ message EpochMillisTimestampValue {
   alloy.protobuf.EpochMillisTimestamp value = 1;
 }
 
-
 message DocumentValue {
   google.protobuf.Value value = 1;
 }
@@ -62,4 +61,48 @@ message SInt32Value {
 
 message SInt64Value {
   sint64 value = 1;
+}
+
+message LocalDateValue {
+  string value = 1;
+}
+
+message LocalTimeValue {
+  string value = 1;
+}
+
+message LocalDateTimeValue {
+  string value = 1;
+}
+
+message OffsetDateTimeValue {
+  string value = 1;
+}
+
+message OffsetTimeValue {
+  string value = 1;
+}
+
+message ZoneIdValue {
+  string value = 1;
+}
+
+message ZoneOffsetValue {
+  string value = 1;
+}
+
+message ZonedDateTimeValue {
+  string value = 1;
+}
+
+message YearValue {
+  uint32 value = 1;
+}
+
+message YearMonth {
+  string value = 1;
+}
+
+message MonthDay {
+  string value = 1;
 }


### PR DESCRIPTION
Adding some protobuf definitions for the `Month` and `DayOfWeek` enum type as well as some compact forms for some of the types. This will go with a PR in the `smithy-translate` repo to be able to translate smithy to protobuf. 