### PR TITLE
Add protobuf encoding formats for timestamp and enum

### DIFF
--- a/modules/core/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
+++ b/modules/core/resources/META-INF/services/software.amazon.smithy.model.traits.TraitService
@@ -32,6 +32,7 @@ alloy.openapi.SummaryTrait$Provider
 alloy.proto.GrpcTrait$Provider
 alloy.proto.ProtoCompactUUIDTrait$Provider
 alloy.proto.ProtoEnabledTrait$Provider
+alloy.proto.ProtoEnumFormatTrait$Provider
 alloy.proto.ProtoIndexTrait$Provider
 alloy.proto.ProtoInlinedOneOfTrait$Provider
 alloy.proto.ProtoNumTypeTrait$Provider

--- a/modules/core/resources/META-INF/smithy/proto/proto.smithy
+++ b/modules/core/resources/META-INF/smithy/proto/proto.smithy
@@ -13,6 +13,7 @@ use alloy#uuidFormat
         protoIndex
         protoNumType
         protoTimestampFormat
+        protoEnumFormat
         protoEnabled
         uncheckedExamples
     ]
@@ -47,10 +48,23 @@ enum protoNumType {
 /// PROTOBUF indicates that the default encoding should be used
 /// EPOCH_MILLIS indicates that an int64 should be used instead of the
 /// default encoding.
+/// RFC3339_STRING indicates that the timestamp should be encoded as a string
+/// using the format described in RFC3339 section 5.6.
 @trait(selector: ":test(timestamp, member > timestamp)")
 enum protoTimestampFormat {
   PROTOBUF
   EPOCH_MILLIS
+  RFC3339_STRING
+}
+
+/// Specifies how enumeration value should be encodeds in protobuf.
+/// ORDINAL indicates that the enum value should be encoded as an integer.
+/// STRING_VALUE indicates that the enum value should be encoded as the
+/// string value.
+@trait(selector: ":test(enum, member > enum)")
+enum protoEnumFormat {
+  ORDINAL
+  STRING_VALUE
 }
 
 /// Marks certain field indexes as unusable by the smithy

--- a/modules/core/src/alloy/proto/ProtoEnumFormatTrait.java
+++ b/modules/core/src/alloy/proto/ProtoEnumFormatTrait.java
@@ -1,0 +1,60 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.proto;
+
+import software.amazon.smithy.model.SourceLocation;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.StringTrait;
+
+public final class ProtoEnumFormatTrait extends StringTrait {
+	public static final String ORDINAL = "ORDINAL";
+	public static final String STRING_VALUE = "STRING_VALUE";
+	public static final String UNKNOWN = "UNKNOWN";
+
+	public static final ShapeId ID = ShapeId.from("alloy.proto#protoEnumFormat");
+
+	public ProtoEnumFormatTrait(String value, SourceLocation sourceLocation) {
+		super(ID, value, sourceLocation);
+	}
+
+	public ProtoEnumFormatTrait(String value) {
+		this(value, SourceLocation.NONE);
+	}
+
+	public EnumFormat getEnumFormat() {
+		return EnumFormat.fromString(getValue());
+	}
+
+	public static final class Provider extends StringTrait.Provider<ProtoEnumFormatTrait> {
+		public Provider() {
+			super(ID, ProtoEnumFormatTrait::new);
+		}
+	}
+
+	public enum EnumFormat {
+		ORDINAL, STRING_VALUE, UNKNOWN;
+
+		public static EnumFormat fromString(String value) {
+			for (EnumFormat format : values()) {
+				if (format.name().equals(value)) {
+					return format;
+				}
+			}
+
+			return UNKNOWN;
+		}
+	}
+}

--- a/modules/core/src/alloy/proto/ProtoTimestampFormatTrait.java
+++ b/modules/core/src/alloy/proto/ProtoTimestampFormatTrait.java
@@ -25,6 +25,7 @@ import software.amazon.smithy.model.traits.StringTrait;
 public final class ProtoTimestampFormatTrait extends StringTrait {
 	public static final String PROTOBUF = "PROTOBUF";
 	public static final String EPOCH_MILLIS = "EPOCH_MILLIS";
+	public static final String RFC3339_STRING = "RFC3339_STRING";
 	public static final String UNKNOWN = "UNKNOWN";
 
 	public static final ShapeId ID = ShapeId.from("alloy.proto#protoTimestampFormat");
@@ -57,7 +58,7 @@ public final class ProtoTimestampFormatTrait extends StringTrait {
 	 * The known {@code protoTimestampFormat} values.
 	 */
 	public enum TimestampFormat {
-		PROTOBUF, EPOCH_MILLIS, UNKNOWN;
+		PROTOBUF, EPOCH_MILLIS, RFC3339_STRING, UNKNOWN;
 
 		/**
 		 * Create a {@code TimestampFormat} from a string that would appear in a model.

--- a/modules/core/test/resources/META-INF/smithy/traits.smithy
+++ b/modules/core/test/resources/META-INF/smithy/traits.smithy
@@ -26,6 +26,7 @@ use alloy.openapi#openapiExtensions
 use alloy.openapi#summary
 use alloy.proto#grpc
 use alloy.proto#protoEnabled
+use alloy.proto#protoEnumFormat
 use alloy.proto#protoIndex
 use alloy.proto#protoInlinedOneOf
 use alloy.proto#protoNumType
@@ -129,6 +130,8 @@ structure ProtoStruct {
 structure ProtoStructTwo {
     @protoTimestampFormat("EPOCH_MILLIS")
     test: Timestamp
+    @protoEnumFormat("STRING_VALUE")
+    enum: TestOpenEnum
 }
 
 @untagged

--- a/modules/docs/protocols/gRPC.md
+++ b/modules/docs/protocols/gRPC.md
@@ -7,6 +7,7 @@ The following traits should be taken into consideration by implementors of the p
 - alloy.proto#protoIndex
 - alloy.proto#protoNumType
 - alloy.proto#protoTimestampFormat
+- alloy.proto#protoEnumFormat
 - alloy.proto#protoWrapped
 - alloy.proto#protoCompactUUID
 

--- a/modules/docs/serialisation/protobuf.md
+++ b/modules/docs/serialisation/protobuf.md
@@ -24,27 +24,30 @@ Below is a table describing how smithy shapes translate to proto constructs.
 Protobuf supports a number of [scalar types](https://developers.google.com/protocol-buffers/docs/proto3#scalar) that do not have first class support in smithy. In order to allow for expressing some of these in smithy, `alloy` provides a `alloy.proto#protoNumType` trait that can refine the meaning of `Integer` or `Long` types in protobuf semantics.
 
 
-| Smithy type          | @protoNumType | @protoTimestampFormat | Proto                                         |
-| -------------------- | ------------- | --------------------- | --------------------------------------------- |
-| boolean              | N/A           | N/A                   | bool                                          |
-| bigDecimal           | N/A           | N/A                   | string                                        |
-| bigInteger           | N/A           | N/A                   | string                                        |
-| blob                 | N/A           | N/A                   | bytes                                         |
-| double               | N/A           | N/A                   | double                                        |
-| float                | N/A           | N/A                   | float                                         |
-| string               | N/A           | N/A                   | string                                        |
-| integer, byte, short | N/A           | N/A                   | int32                                         |
-| integer, byte, short | FIXED         | N/A                   | fixed32                                       |
-| integer, byte, short | FIXED_SIGNED  | N/A                   | sfixed32                                      |
-| integer, byte, short | SIGNED        | N/A                   | sint32                                        |
-| integer, byte, short | UNSIGNED      | N/A                   | uint32                                        |
-| long                 | N/A           | N/A                   | int64                                         |
-| long                 | FIXED         | N/A                   | fixed64                                       |
-| long                 | FIXED_SIGNED  | N/A                   | sfixed64                                      |
-| long                 | SIGNED        | N/A                   | sint64                                        |
-| long                 | UNSIGNED      | N/A                   | uint64                                        |
-| timestamp            | N/A           | none or PROTOBUF      | message { long seconds = 1; long nanos = 2; } |
-| timestamp            | N/A           | EPOCH_MILLIS          | message { long milliseconds = 1;              |
+| Smithy type          | @protoNumType | @protoTimestampFormat | @protoEnumFromat | Proto                                         |
+| -------------------- | ------------- | --------------------- | ---------------- | --------------------------------------------- |
+| boolean              | N/A           | N/A                   | N/A              | bool                                          |
+| bigDecimal           | N/A           | N/A                   | N/A              | string                                        |
+| bigInteger           | N/A           | N/A                   | N/A              | string                                        |
+| blob                 | N/A           | N/A                   | N/A              | bytes                                         |
+| double               | N/A           | N/A                   | N/A              | double                                        |
+| float                | N/A           | N/A                   | N/A              | float                                         |
+| string               | N/A           | N/A                   | N/A              | string                                        |
+| integer, byte, short | N/A           | N/A                   | N/A              | int32                                         |
+| integer, byte, short | FIXED         | N/A                   | N/A              | fixed32                                       |
+| integer, byte, short | FIXED_SIGNED  | N/A                   | N/A              | sfixed32                                      |
+| integer, byte, short | SIGNED        | N/A                   | N/A              | sint32                                        |
+| integer, byte, short | UNSIGNED      | N/A                   | N/A              | uint32                                        |
+| long                 | N/A           | N/A                   | N/A              | int64                                         |
+| long                 | FIXED         | N/A                   | N/A              | fixed64                                       |
+| long                 | FIXED_SIGNED  | N/A                   | N/A              | sfixed64                                      |
+| long                 | SIGNED        | N/A                   | N/A              | sint64                                        |
+| long                 | UNSIGNED      | N/A                   | N/A              | uint64                                        |
+| timestamp            | N/A           | none or PROTOBUF      | N/A              | message { long seconds = 1; long nanos = 2; } |
+| timestamp            | N/A           | EPOCH_MILLIS          | N/A              | message { long milliseconds = 1; }            |
+| timestamp            | N/A           | RFC3339_STRING        | N/A              | string                                        |
+| enum                 | N/A           | N/A                   | none or ORDINAL  | int32                                         |
+| enum                 | N/A           | N/A                   | STRING_VALUE     | string                                        |
 
 #### alloy.proto#protoWrapped
 
@@ -103,7 +106,20 @@ See [here](https://protobuf.dev/programming-guides/proto3/#scalar) for documenta
 
 Timestamp shapes can be annotated with the `@alloy.proto#protoTimestampFormat` trait in order to signal what type of encoding should be used for timestamps in proto serialisation/deserialisation.
 
-Possible values are `PROTOBUF` and `EPOCH_MILLIS`. `PROTOBUF` is the default that is used in the absence of this trait. When `EPOCH_MILLIS` is specified then the timestamp will be represented as a wrapped `int64` in the corresponding proto definition.
+Possible values are `PROTOBUF`, `EPOCH_MILLIS` and `RFC3339_STRING`. `PROTOBUF` is the default that is used in the absence of this trait. When `EPOCH_MILLIS` is specified then the timestamp will be represented as a wrapped `int64` in the corresponding proto definition. When `RFC3339_STRING` is specified, the timestmap should be serialized as a `string` in the format described by [RFC3339 section 5.6](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6).
+
+#### alloy.protoEnumFormat
+
+Enum shapes can be annotated with the `@alloy.proto#protoEnumFormat` trait to indicate the encoding that should be used to serialize enumeration values in protobuf.
+
+Possible values are `ORDINAL` and `STRING_VALUE`. `ORDINAL` is the default encoding that will be use in the absence of the trait and means that enumeration values should be encoded using an `int32` reprensenting the index associated with each enumeration value. When `STRING_VALUE` is specified, enumeration values should be encoded as a `string` containing the value defined in the smithy specification. For instance, the `APPLE` value from the following definition will be serialized as the `apple` string.
+
+```
+@alloy.proto#protoEnumFormat("STRING_VALUE")
+enum Fruit {
+  APPLE = "apple"
+}
+```
 
 #### UUIDs
 


### PR DESCRIPTION
* Add `protoTimestampFormat$RFC3999_STRING` to indicate that a timestamp should be serialized as a string.
* Add `protoEnumFormat` to specify the format to use when serializing an enumeration.