### PR TITLE
fix naming of wrapped types

### DIFF
--- a/modules/protobuf/resources/alloy/protobuf/wrappers.proto
+++ b/modules/protobuf/resources/alloy/protobuf/wrappers.proto
@@ -115,10 +115,10 @@ message YearValue {
   uint32 value = 1;
 }
 
-message YearMonth {
+message YearMonthValue {
   string value = 1;
 }
 
-message MonthDay {
+message MonthDayValue {
   string value = 1;
 }


### PR DESCRIPTION
Not necessarily a bug, but the Proto wrapped types for these two don't have the `Value` suffix so it's different from the rest of the Proto wrapped types.