### PR TITLE
revert org change

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The goals of alloy are :
 The core alloy library, containing shapes and validators, is published to Maven Central at the following coordinates.
 
 ```
-io.github.disneystreaming.alloy:alloy-core:x.y.z
+com.disneystreaming.alloy:alloy-core:x.y.z
 ```
 
 It contains, in particular, traits and validators associated to the following aspects :
@@ -62,7 +62,7 @@ Alloy provides a suite of protocol tests that utilise the [AWS HTTP Protocol Com
 These tests are available on maven central at the following coordinates :
 
 ```
-io.github.disneystreaming.alloy:alloy-protocol-tests:x.y.z
+com.disneystreaming.alloy:alloy-protocol-tests:x.y.z
 ```
 
 ## Working on Alloy

--- a/build.sc
+++ b/build.sc
@@ -59,7 +59,7 @@ trait BasePublishModule extends BaseModule with SonatypeCentralPublishModule {
 
   def pomSettings = PomSettings(
     description = "Common Smithy Shapes",
-    organization = "io.github.disneystreaming.alloy",
+    organization = "com.disneystreaming.alloy",
     url = "https://github.com/disneystreaming/alloy",
     licenses = Seq(
       License(

--- a/modules/docs/overview.md
+++ b/modules/docs/overview.md
@@ -25,7 +25,7 @@ The goals of alloy are :
 The core alloy library, containing shapes and validators, is published to Maven Central at the following coordinates.
 
 ```
-io.github.disneystreaming.alloy:alloy-core:x.y.z
+com.disneystreaming.alloy:alloy-core:x.y.z
 ```
 
 It contains, in particular, traits and validators associated to the following aspects :
@@ -57,5 +57,5 @@ Alloy provides a suite of protocol tests that utilise the [AWS HTTP Protocol Com
 These tests are available on maven central at the following coordinates :
 
 ```
-io.github.disneystreaming.alloy:alloy-protocol-tests:x.y.z
+com.disneystreaming.alloy:alloy-protocol-tests:x.y.z
 ```

--- a/modules/docs/protocols/gRPC.md
+++ b/modules/docs/protocols/gRPC.md
@@ -56,7 +56,7 @@ lazy val `proto-hints` = (project in file("proto-hints"))
   .settings(
     name := "proto-hints",
     libraryDependencies ++= Seq(
-      "io.github.disneystreaming.alloy" % "alloy-core" % "0.2.8" % Smithy4s,
+      "com.disneystreaming.alloy" % "alloy-core" % "0.2.8" % Smithy4s,
       "com.disneystreaming.smithy4s" %% "smithy4s-core" % smithy4sVersion.value
     ),
     Compile / smithy4sAllowedNamespaces := List("alloy.proto")

--- a/modules/docs/serialisation/protobuf.md
+++ b/modules/docs/serialisation/protobuf.md
@@ -9,7 +9,7 @@ For full documentation on what each of these traits does, see the smithy specifi
 Note that for convenience, `alloy` provides a module containing protobuf definitions that used downstream to ensure that the semantics described in this document are respected.
 
 ```
-io.github.disneystreaming.alloy:alloy-protobuf:x.y.z
+com.disneystreaming.alloy:alloy-protobuf:x.y.z
 ```
 
 ### Validation


### PR DESCRIPTION
Now that we were able to migrate `com.disneystreaming` to the new sonatype, we should revert the organization change here and in smithy translate.