### PR TITLE
Update scalafmt: 3.7.3 -> 3.9.9

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.7.3"
+version = "3.9.9"
 runner.dialect = scala213
 fileOverride {
   "glob:**/modules/core/test/src/**" {

--- a/modules/openapi/src/alloy/openapi/package.scala
+++ b/modules/openapi/src/alloy/openapi/package.scala
@@ -86,7 +86,7 @@ package object openapi {
       model.getServiceShapes().asScala.toSet[Shape]
 
     val filteredServices = allowedNS match {
-      case None => serviceShapes
+      case None             => serviceShapes
       case Some(namespaces) =>
         serviceShapes.filter(s => namespaces.contains(s.getId.getNamespace()))
     }

--- a/modules/openapi/src/software/amazon/smithy/openapi/fromsmithy/protocols/AlloyAbstractRestProtocol.scala
+++ b/modules/openapi/src/software/amazon/smithy/openapi/fromsmithy/protocols/AlloyAbstractRestProtocol.scala
@@ -121,9 +121,8 @@ abstract class AlloyAbstractRestProtocol[T <: Trait]
           .foreach(builder.requestBody)
         createResponses(context, bindingIndex, operation)
           .foreach { case (k, values) =>
-            combineResponseContent(values, k).foreach(v =>
-              builder.putResponse(k, v)
-            )
+            combineResponseContent(values, k)
+              .foreach(v => builder.putResponse(k, v))
           }
         Operation.create(method, uri, builder)
       })
@@ -134,8 +133,8 @@ abstract class AlloyAbstractRestProtocol[T <: Trait]
       statusCode: String
   ): Option[ResponseObject] = {
     responses match {
-      case Nil         => None
-      case head :: Nil => Some(head)
+      case Nil          => None
+      case head :: Nil  => Some(head)
       case head :: tail =>
         val all = head +: tail
         val mediaTypeObjects: List[MediaTypeObject] =
@@ -346,7 +345,7 @@ abstract class AlloyAbstractRestProtocol[T <: Trait]
       val visitor = new HeaderSchemaVisitor[T](context, startingSchema, member)
       val visitedSchema = target.accept(visitor)
       val schemaVerified = getHeaderTimestampFormat(context, member) match {
-        case None => visitedSchema
+        case None         => visitedSchema
         case Some(format) =>
           val copiedBuilder = ModelUtils.convertSchemaToStringBuilder(
             visitedSchema


### PR DESCRIPTION
Fixes the annoying errors in checkFormat too:

```
[19] error: /Users/kubukoz/projects/alloy/modules/openapi/src/software/amazon/smithy/openapi/fromsmithy/protocols/AlloyAbstractRestProtocol.scala: java.util.NoSuchElementException: last of empty IndexedSeq
[19] 	at scala.collection.IndexedSeqOps.last(IndexedSeq.scala:110)
[19] 	at scala.collection.IndexedSeqOps.last$(IndexedSeq.scala:105)
[19] 	at scala.meta.tokens.Tokens.last(Tokens.scala:29)
[19] 	at org.scalafmt.internal.Router.$anonfun$getSplitsImpl$118(Router.scala:834)
[19] 	at scala.Option.map(Option.scala:242)
[19] 	at org.scalafmt.internal.Router.getSplitsImpl(Router.scala:833)
[19] 	at org.scalafmt.internal.Router.getSplits(Router.scala:2674)
[19] 	at org.scalafmt.internal.BestFirstSearch.$anonfun$routes$1(BestFirstSearch.scala:37)
[19] 	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:619)
[19] 	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:617)
[19] 	at org.scalafmt.internal.FormatTokens.foreach(FormatTokens.scala:12)
[19] 	at org.scalafmt.internal.BestFirstSearch.<init>(BestFirstSearch.scala:37)
```