### PR TITLE
Add common IP Address traits

### DIFF
--- a/modules/core/resources/META-INF/smithy/common/common.smithy
+++ b/modules/core/resources/META-INF/smithy/common/common.smithy
@@ -29,3 +29,16 @@ structure languageTagFormat { }
 /// example: "#09C" (short) or "#0099CC" (full)
 @trait(selector: ":test(string, member > string)")
 structure hexColorCodeFormat { }
+
+/// IP Address, supporting both v4 and v6 addresses
+/// IETF RFC: https://www.rfc-editor.org/rfc/rfc791
+///   v6 RFC: https://www.rfc-editor.org/rfc/rfc1883
+/// example: "192.168.1.1", "::1"
+@trait(selector: ":test(string, member > string)")
+structure ipaddressFormat { }
+
+/// IP Address range using CIDR 
+/// IETF RFC: https://www.rfc-editor.org/rfc/rfc1817
+/// example: "192.0.2.0/24", "2001:db8::/32"
+@trait(selector: ":test(string, member > string)")
+structure cidrFormat { }

--- a/modules/core/src/alloy/common/CidrFormatTrait.java
+++ b/modules/core/src/alloy/common/CidrFormatTrait.java
@@ -1,0 +1,46 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.common;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AnnotationTrait;
+import software.amazon.smithy.model.traits.AbstractTrait;
+
+public class CidrFormatTrait extends AnnotationTrait {
+
+	public static ShapeId ID = ShapeId.from("alloy.common#cidrFormat");
+
+	public CidrFormatTrait(ObjectNode node) {
+		super(ID, node);
+	}
+
+	public CidrFormatTrait() {
+		super(ID, Node.objectNode());
+	}
+
+	public static final class Provider extends AbstractTrait.Provider {
+		public Provider() {
+			super(ID);
+		}
+
+		@Override
+		public CidrFormatTrait createTrait(ShapeId target, Node node) {
+			return new CidrFormatTrait(node.expectObjectNode());
+		}
+	}
+}

--- a/modules/core/src/alloy/common/IpAddressFormatTrait.java
+++ b/modules/core/src/alloy/common/IpAddressFormatTrait.java
@@ -1,0 +1,46 @@
+/* Copyright 2022 Disney Streaming
+ *
+ * Licensed under the Tomorrow Open Source Technology License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://disneystreaming.github.io/TOST-1.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alloy.common;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.AnnotationTrait;
+import software.amazon.smithy.model.traits.AbstractTrait;
+
+public class IpAddressFormatTrait extends AnnotationTrait {
+
+	public static ShapeId ID = ShapeId.from("alloy.common#ipaddressFormat");
+
+	public IpAddressFormatTrait(ObjectNode node) {
+		super(ID, node);
+	}
+
+	public IpAddressFormatTrait() {
+		super(ID, Node.objectNode());
+	}
+
+	public static final class Provider extends AbstractTrait.Provider {
+		public Provider() {
+			super(ID);
+		}
+
+		@Override
+		public IpAddressFormatTrait createTrait(ShapeId target, Node node) {
+			return new IpAddressFormatTrait(node.expectObjectNode());
+		}
+	}
+}


### PR DESCRIPTION
Introduces 2 new common format traits for IP Addresses and IP Address Ranges.

Useful for services that pass around IP as inputs, while unlocking the potential for more robust and descriptive validation than simple pattern matching.

Recommended to implement validation/refinement using https://github.com/seancfoley/IPAddress