### PR TITLE
downgrade severity of proto index event

### DIFF
--- a/modules/core/src/alloy/proto/validation/ProtoIndexTraitValidator.java
+++ b/modules/core/src/alloy/proto/validation/ProtoIndexTraitValidator.java
@@ -114,7 +114,7 @@ final public class ProtoIndexTraitValidator extends AbstractValidator {
 			} else {
 				openEnumChecks = Stream.of(ValidationEvent.builder().id(OPEN_ENUM_MUST_NOT_HAVE_INDEXES)
 						.message("Members of enumeration" + shape + "must not have the `@protoIndex` trait applied.")
-						.shape(shape).severity(Severity.ERROR).build());
+						.shape(shape).severity(Severity.WARNING).build());
 			}
 		} else {
 			Stream.empty();


### PR DESCRIPTION
This is for open enumerations. We have some internal use cases where open enums are translated to proto enums which are open in proto 3 anyway. I think we should align the alloy and smithy translate behavior on this in the future, but for now downgrading this will unblock some use cases and we can revisit in the future.