### PR TITLE
fix data examples openapi mapping bug

### DIFF
--- a/modules/openapi/src/alloy/openapi/DataExamplesMapper.scala
+++ b/modules/openapi/src/alloy/openapi/DataExamplesMapper.scala
@@ -60,7 +60,12 @@ class DataExamplesMapper() extends JsonSchemaMapper {
     if (example.getExampleType == DataExamplesTrait.DataExampleType.STRING) {
       val maybeStrNode = example.getContent().asStringNode()
       if (maybeStrNode.isPresent) {
-        Node.parse(maybeStrNode.get.getValue)
+        val strNode = maybeStrNode.get
+        // A STRING example may hold arbitrary content (e.g. XML or another
+        // non-JSON encoding). Parse it as JSON when possible so it renders as
+        // a structured example, otherwise fall back to the raw string node
+        // instead of failing the whole conversion.
+        scala.util.Try(Node.parse(strNode.getValue)).getOrElse(strNode)
       } else {
         ObjectNode.builder().build()
       }

--- a/modules/openapi/test/resources/foo.smithy
+++ b/modules/openapi/test/resources/foo.smithy
@@ -269,6 +269,9 @@ map Attributes {
     {
         string: "{\"values\": []}"
     }
+    {
+        string: "<values></values>"
+    }
 ])
 structure ValuesResponse {
     values: Values

--- a/modules/openapi/test/resources/foo_3.1.0.json
+++ b/modules/openapi/test/resources/foo_3.1.0.json
@@ -599,7 +599,8 @@
                 "examples": [
                     {
                         "values": []
-                    }
+                    },
+                    "<values></values>"
                 ]
             },
             "GreetOutputPayload": {


### PR DESCRIPTION
Fixes an issue with DataExamplesMapper where it attempts to use JSON even in the case of a `string` data example. The change now is it will still try to do this, but if it is unable to it will fallback to a simple StringNode.