### PR TITLE
Relax StructurePattern validation rules to also work for unions

### DIFF
--- a/modules/core/resources/META-INF/smithy/string.smithy
+++ b/modules/core/resources/META-INF/smithy/string.smithy
@@ -7,6 +7,6 @@ structure structurePattern {
   @required
   pattern: String,
   @required
-  @idRef(selector: "structure")
+  @idRef(selector: ":is(structure, union)")
   target: String
 }

--- a/modules/core/src/alloy/validation/StructurePatternTraitValidator.java
+++ b/modules/core/src/alloy/validation/StructurePatternTraitValidator.java
@@ -37,6 +37,7 @@ public final class StructurePatternTraitValidator extends AbstractValidator {
 	@Override
 	public List<ValidationEvent> validate(Model model) {
 		List<ValidationEvent> events = new ArrayList<>();
+
 		model.getStringShapesWithTrait(StructurePatternTrait.class).forEach(patternShape -> {
 			StructurePatternTrait trt = patternShape.expectTrait(StructurePatternTrait.class);
 			Shape targetShape = model.expectShape(trt.getTarget());
@@ -95,8 +96,8 @@ public final class StructurePatternTraitValidator extends AbstractValidator {
 			if (!(memberTarget instanceof SimpleShape) || memberTarget instanceof DocumentShape) {
 				events.add(error(patternShape,
 						String.format(
-								"Union members must target simple shapes (excluding document), but '%s' targets '%s'",
-								key, memberTarget.toShapeId())));
+								"Union members must target simple shapes (excluding document), but '%s' targets '%s', which is a '%s'",
+								key, memberTarget.toShapeId(), memberTarget.getType())));
 			}
 		});
 

--- a/modules/core/src/alloy/validation/StructurePatternTraitValidator.java
+++ b/modules/core/src/alloy/validation/StructurePatternTraitValidator.java
@@ -17,9 +17,12 @@ package alloy.validation;
 
 import alloy.StructurePatternTrait;
 import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.DocumentShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.SimpleShape;
+import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.model.validation.AbstractValidator;
 import software.amazon.smithy.model.validation.ValidationEvent;
@@ -36,34 +39,67 @@ public final class StructurePatternTraitValidator extends AbstractValidator {
 		List<ValidationEvent> events = new ArrayList<>();
 		model.getStringShapesWithTrait(StructurePatternTrait.class).forEach(patternShape -> {
 			StructurePatternTrait trt = patternShape.expectTrait(StructurePatternTrait.class);
-			List<String> patternParams = getParamNamesInPattern(trt.getPattern());
-			StructureShape struct = model.expectShape(trt.getTarget()).asStructureShape().get();
-			ArrayList<String> structureParamNames = new ArrayList<>(struct.getMemberNames());
-			structureParamNames.removeAll(patternParams);
+			Shape targetShape = model.expectShape(trt.getTarget());
 
-			if (!structureParamNames.isEmpty()) {
-				events.add(error(patternShape, "Did not find pattern params for the following members: "
-						+ String.join(", ", structureParamNames)));
+			if (targetShape instanceof StructureShape) {
+				validateStructureTarget(model, patternShape, trt, (StructureShape) targetShape, events);
+			} else if (targetShape instanceof UnionShape) {
+				validateUnionTarget(model, patternShape, trt, (UnionShape) targetShape, events);
 			}
 
-			struct.getAllMembers().forEach((key, value) -> {
-				Shape targetShape = model.expectShape(value.getTarget());
-				if (!(targetShape instanceof SimpleShape)) {
-					events.add(error(patternShape,
-							String.format("Pattern params must target simple shapes only, but '%s' targets '%s'", key,
-									targetShape.toShapeId())));
-				}
-                if (!value.hasTrait(RequiredTrait.class)) {
-                    events.add(error(patternShape, String.format("Pattern params must not target optional structure members, but '%s' is optional", key)));
-                }
-			});
-
-            if (trt.getPattern().contains("}{")) {
-                events.add(error(patternShape, "Params must be separated by at least one character"));
-            }
+			if (trt.getPattern().contains("}{")) {
+				events.add(error(patternShape, "Params must be separated by at least one character"));
+			}
 		});
 
 		return events;
+	}
+
+	private void validateStructureTarget(Model model, StringShape patternShape, StructurePatternTrait trt,
+			StructureShape struct, List<ValidationEvent> events) {
+		List<String> patternParams = getParamNamesInPattern(trt.getPattern());
+		ArrayList<String> structureParamNames = new ArrayList<>(struct.getMemberNames());
+		structureParamNames.removeAll(patternParams);
+
+		if (!structureParamNames.isEmpty()) {
+			events.add(error(patternShape, "Did not find pattern params for the following members: "
+					+ String.join(", ", structureParamNames)));
+		}
+
+		struct.getAllMembers().forEach((key, value) -> {
+			Shape memberTarget = model.expectShape(value.getTarget());
+			if (!(memberTarget instanceof SimpleShape) || memberTarget instanceof DocumentShape) {
+				events.add(error(patternShape,
+						String.format("Pattern params must target simple shapes only, but '%s' targets '%s'", key,
+								memberTarget.toShapeId())));
+			}
+			if (!value.hasTrait(RequiredTrait.class)) {
+				events.add(error(patternShape, String.format(
+						"Pattern params must not target optional structure members, but '%s' is optional", key)));
+			}
+		});
+	}
+
+	private void validateUnionTarget(Model model, StringShape patternShape, StructurePatternTrait trt,
+			UnionShape union, List<ValidationEvent> events) {
+		List<String> patternParams = getParamNamesInPattern(trt.getPattern());
+
+		if (patternParams.size() != 2 || !patternParams.contains("label") || !patternParams.contains("value")) {
+			events.add(error(patternShape,
+					"When target is a union, the pattern must contain exactly '{label}' and '{value}'"));
+			return;
+		}
+
+		union.getAllMembers().forEach((key, value) -> {
+			Shape memberTarget = model.expectShape(value.getTarget());
+			if (!(memberTarget instanceof SimpleShape) || memberTarget instanceof DocumentShape) {
+				events.add(error(patternShape,
+						String.format(
+								"Union members must target simple shapes (excluding document), but '%s' targets '%s'",
+								key, memberTarget.toShapeId())));
+			}
+		});
+
 	}
 
 	private List<String> getParamNamesInPattern(String pattern) {
@@ -71,9 +107,7 @@ public final class StructurePatternTraitValidator extends AbstractValidator {
 		Matcher matcher = pat.matcher(pattern);
 		ArrayList<String> results = new ArrayList<>();
 		while (matcher.find()) {
-			for (int j = 0; j <= matcher.groupCount(); j++) {
-				results.add(matcher.group(j));
-			}
+			results.add(matcher.group(1));
 		}
 		return results;
 	}

--- a/modules/core/test/src/alloy/validation/StructurePatternTraitValidatorSpec.scala
+++ b/modules/core/test/src/alloy/validation/StructurePatternTraitValidatorSpec.scala
@@ -19,6 +19,7 @@ import alloy.StructurePatternTrait
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.validation.ValidationEvent
 import software.amazon.smithy.model.validation.Severity
@@ -283,6 +284,236 @@ final class StructurePatternTraitValidatorSpec extends munit.FunSuite {
         .severity(Severity.ERROR)
         .message(
           "Params must be separated by at least one character"
+        )
+        .build()
+    )
+    assertEquals(result, expected)
+  }
+
+  test("union - no error") {
+    val targetId = ShapeId.fromParts("test", "MyUnion")
+    val patternTrait = StructurePatternTrait
+      .builder()
+      .setPattern("{label}:{value}")
+      .setTarget(targetId)
+      .build()
+    val stringShape = StringShape
+      .builder()
+      .id(ShapeId.fromParts("test", "MyString"))
+      .addTrait(patternTrait)
+      .build()
+    val unionShape = UnionShape
+      .builder()
+      .id(targetId)
+      .addMember(
+        MemberShape
+          .builder()
+          .id(targetId.withMember("one"))
+          .target(ShapeId.fromParts("smithy.api", "String"))
+          .build()
+      )
+      .addMember(
+        MemberShape
+          .builder()
+          .id(targetId.withMember("two"))
+          .target(ShapeId.fromParts("smithy.api", "Integer"))
+          .build()
+      )
+      .build()
+
+    val model =
+      Model.assembler.disableValidation
+        .addShapes(unionShape, stringShape)
+        .assemble()
+        .unwrap()
+
+    val result = validator.validate(model).asScala.toList
+
+    assertEquals(result, List.empty)
+  }
+
+  test("union - missing magic identifiers") {
+    val targetId = ShapeId.fromParts("test", "MyUnion")
+    val patternTrait = StructurePatternTrait
+      .builder()
+      .setPattern("{foo}-{bar}")
+      .setTarget(targetId)
+      .build()
+    val stringShape = StringShape
+      .builder()
+      .id(ShapeId.fromParts("test", "MyString"))
+      .addTrait(patternTrait)
+      .build()
+    val unionShape = UnionShape
+      .builder()
+      .id(targetId)
+      .addMember(
+        MemberShape
+          .builder()
+          .id(targetId.withMember("one"))
+          .target(ShapeId.fromParts("smithy.api", "String"))
+          .build()
+      )
+      .build()
+
+    val model =
+      Model.assembler.disableValidation
+        .addShapes(unionShape, stringShape)
+        .assemble()
+        .unwrap()
+
+    val result = validator.validate(model).asScala.toList
+
+    val expected = List(
+      ValidationEvent
+        .builder()
+        .id("StructurePatternTrait")
+        .shape(stringShape)
+        .severity(Severity.ERROR)
+        .message(
+          "When target is a union, the pattern must contain exactly '{label}' and '{value}'"
+        )
+        .build()
+    )
+    assertEquals(result, expected)
+  }
+
+  test("union - member targets non-simple shape") {
+    val targetId = ShapeId.fromParts("test", "MyUnion")
+    val patternTrait = StructurePatternTrait
+      .builder()
+      .setPattern("{label}:{value}")
+      .setTarget(targetId)
+      .build()
+    val stringShape = StringShape
+      .builder()
+      .id(ShapeId.fromParts("test", "MyString"))
+      .addTrait(patternTrait)
+      .build()
+    val otherStruct = StructureShape
+      .builder()
+      .id(ShapeId.fromParts("test", "OtherStruct"))
+      .build()
+    val unionShape = UnionShape
+      .builder()
+      .id(targetId)
+      .addMember(
+        MemberShape
+          .builder()
+          .id(targetId.withMember("one"))
+          .target(otherStruct.toShapeId)
+          .build()
+      )
+      .build()
+
+    val model =
+      Model.assembler.disableValidation
+        .addShapes(otherStruct, unionShape, stringShape)
+        .assemble()
+        .unwrap()
+
+    val result = validator.validate(model).asScala.toList
+
+    val expected = List(
+      ValidationEvent
+        .builder()
+        .id("StructurePatternTrait")
+        .shape(stringShape)
+        .severity(Severity.ERROR)
+        .message(
+          "Union members must target simple shapes (excluding document), but 'one' targets 'test#OtherStruct'"
+        )
+        .build()
+    )
+    assertEquals(result, expected)
+  }
+
+  test("union - no separator between params") {
+    val targetId = ShapeId.fromParts("test", "MyUnion")
+    val patternTrait = StructurePatternTrait
+      .builder()
+      .setPattern("{label}{value}")
+      .setTarget(targetId)
+      .build()
+    val stringShape = StringShape
+      .builder()
+      .id(ShapeId.fromParts("test", "MyString"))
+      .addTrait(patternTrait)
+      .build()
+    val unionShape = UnionShape
+      .builder()
+      .id(targetId)
+      .addMember(
+        MemberShape
+          .builder()
+          .id(targetId.withMember("one"))
+          .target(ShapeId.fromParts("smithy.api", "String"))
+          .build()
+      )
+      .build()
+
+    val model =
+      Model.assembler.disableValidation
+        .addShapes(unionShape, stringShape)
+        .assemble()
+        .unwrap()
+
+    val result = validator.validate(model).asScala.toList
+
+    val expected = List(
+      ValidationEvent
+        .builder()
+        .id("StructurePatternTrait")
+        .shape(stringShape)
+        .severity(Severity.ERROR)
+        .message(
+          "Params must be separated by at least one character"
+        )
+        .build()
+    )
+    assertEquals(result, expected)
+  }
+
+  test("union - member targets document shape") {
+    val targetId = ShapeId.fromParts("test", "MyUnion")
+    val patternTrait = StructurePatternTrait
+      .builder()
+      .setPattern("{label}:{value}")
+      .setTarget(targetId)
+      .build()
+    val stringShape = StringShape
+      .builder()
+      .id(ShapeId.fromParts("test", "MyString"))
+      .addTrait(patternTrait)
+      .build()
+    val unionShape = UnionShape
+      .builder()
+      .id(targetId)
+      .addMember(
+        MemberShape
+          .builder()
+          .id(targetId.withMember("one"))
+          .target(ShapeId.fromParts("smithy.api", "Document"))
+          .build()
+      )
+      .build()
+
+    val model =
+      Model.assembler.disableValidation
+        .addShapes(unionShape, stringShape)
+        .assemble()
+        .unwrap()
+
+    val result = validator.validate(model).asScala.toList
+
+    val expected = List(
+      ValidationEvent
+        .builder()
+        .id("StructurePatternTrait")
+        .shape(stringShape)
+        .severity(Severity.ERROR)
+        .message(
+          "Union members must target simple shapes (excluding document), but 'one' targets 'smithy.api#Document'"
         )
         .build()
     )

--- a/modules/core/test/src/alloy/validation/StructurePatternTraitValidatorSpec.scala
+++ b/modules/core/test/src/alloy/validation/StructurePatternTraitValidatorSpec.scala
@@ -421,7 +421,7 @@ final class StructurePatternTraitValidatorSpec extends munit.FunSuite {
         .shape(stringShape)
         .severity(Severity.ERROR)
         .message(
-          "Union members must target simple shapes (excluding document), but 'one' targets 'test#OtherStruct'"
+          "Union members must target simple shapes (excluding document), but 'one' targets 'test#OtherStruct', which is a 'structure'"
         )
         .build()
     )
@@ -513,7 +513,7 @@ final class StructurePatternTraitValidatorSpec extends munit.FunSuite {
         .shape(stringShape)
         .severity(Severity.ERROR)
         .message(
-          "Union members must target simple shapes (excluding document), but 'one' targets 'smithy.api#Document'"
+          "Union members must target simple shapes (excluding document), but 'one' targets 'smithy.api#Document', which is a 'document'"
         )
         .build()
     )

--- a/modules/docs/misc/constraints.md
+++ b/modules/docs/misc/constraints.md
@@ -55,7 +55,9 @@ intEnum IntShape {
 
 ### alloy#structurePattern
 
-The `alloy#structurePattern` trait provides a way to specify that a given `String` will conform to a provided format and that it should be parsed into a `Structure` rather than a `String`. For example:
+The `alloy#structurePattern` trait provides a way to specify that a given `String` will conform to a provided format and that it should be parsed into a `Structure` or a `Union` rather than remaining an opaque `String`.
+
+#### Targeting a structure
 
 ```smithy
 @structurePattern(pattern: "{foo}_{bar}", target: FooBar)
@@ -69,11 +71,30 @@ structure FooBar {
 }
 ```
 
-Now wherever `FooBarString` is used, it will really be parsing the string into the structure `FooBar`. There are a few requirements for using the `structurePattern` trait that are checked by a validator:
+Now wherever `FooBarString` is used, it will really be parsing the string into the structure `FooBar`. There are a few requirements for using the `structurePattern` trait with a structure target that are checked by a validator:
 
-- The target structure must have all required members and all members must target simple shapes.
+- The target structure must have all required members and all members must target simple shapes (excluding document).
 - The provided pattern must have all parameters separated by at least one character. The reason for this is that if there is no separation (e.g. "{foo}{bar}") then a parser would not be able to tell when one starts and the other begins.
 - There must be a provided pattern parameter for each member of the target structure.
+
+#### Targeting a union
+
+When the target is a union, the pattern must use exactly the magic identifiers `{label}` and `{value}`. The `{label}` acts as a discriminator identifying which union member is active, and `{value}` carries the payload.
+
+```smithy
+@structurePattern(pattern: "{label}:{value}", target: MyUnion)
+string MyUnionString
+
+union MyUnion {
+  foo: String
+  bar: Integer
+}
+```
+
+Requirements when targeting a union:
+
+- The pattern must contain exactly `{label}` and `{value}`, separated by at least one character.
+- All union members must target simple shapes (excluding document).
 
 
 ### Datetime constraints

--- a/modules/docs/misc/constraints.md
+++ b/modules/docs/misc/constraints.md
@@ -77,6 +77,63 @@ Now wherever `FooBarString` is used, it will really be parsing the string into t
 - The provided pattern must have all parameters separated by at least one character. The reason for this is that if there is no separation (e.g. "{foo}{bar}") then a parser would not be able to tell when one starts and the other begins.
 - There must be a provided pattern parameter for each member of the target structure.
 
+The following examples are **invalid** and will produce validation errors:
+
+```smithy
+// ERROR: pattern params must not target optional structure members
+@structurePattern(pattern: "{foo}_{bar}", target: FooBar)
+string FooBarString
+
+structure FooBar {
+  @required
+  foo: String
+  bar: Integer // missing @required
+}
+```
+
+```smithy
+// ERROR: pattern params must target simple shapes only
+@structurePattern(pattern: "{foo}_{bar}", target: FooBar)
+string FooBarString
+
+structure FooBar {
+  @required
+  foo: String
+  @required
+  bar: SomeStructure // not a simple shape
+}
+
+structure SomeStructure {}
+```
+
+```smithy
+// ERROR: params must be separated by at least one character
+@structurePattern(pattern: "{foo}{bar}", target: FooBar)
+string FooBarString
+
+structure FooBar {
+  @required
+  foo: String
+  @required
+  bar: Integer
+}
+```
+
+```smithy
+// ERROR: did not find pattern params for the following members: baz
+@structurePattern(pattern: "{foo}_{bar}", target: FooBar)
+string FooBarString
+
+structure FooBar {
+  @required
+  foo: String
+  @required
+  bar: Integer
+  @required
+  baz: String // no matching {baz} in pattern
+}
+```
+
 #### Targeting a union
 
 When the target is a union, the pattern must use exactly the magic identifiers `{label}` and `{value}`. The `{label}` acts as a discriminator identifying which union member is active, and `{value}` carries the payload.
@@ -95,6 +152,53 @@ Requirements when targeting a union:
 
 - The pattern must contain exactly `{label}` and `{value}`, separated by at least one character.
 - All union members must target simple shapes (excluding document).
+
+The following examples are **invalid** and will produce validation errors:
+
+```smithy
+// ERROR: pattern must contain exactly '{label}' and '{value}'
+@structurePattern(pattern: "{foo}-{bar}", target: MyUnion)
+string MyUnionString
+
+union MyUnion {
+  one: String
+  two: Integer
+}
+```
+
+```smithy
+// ERROR: params must be separated by at least one character
+@structurePattern(pattern: "{label}{value}", target: MyUnion)
+string MyUnionString
+
+union MyUnion {
+  one: String
+}
+```
+
+```smithy
+// ERROR: union members must target simple shapes (excluding document),
+//        but 'one' targets 'SomeStructure', which is a 'structure'
+@structurePattern(pattern: "{label}:{value}", target: MyUnion)
+string MyUnionString
+
+union MyUnion {
+  one: SomeStructure // not a simple shape
+}
+
+structure SomeStructure {}
+```
+
+```smithy
+// ERROR: union members must target simple shapes (excluding document),
+//        but 'one' targets 'Document', which is a 'document'
+@structurePattern(pattern: "{label}:{value}", target: MyUnion)
+string MyUnionString
+
+union MyUnion {
+  one: Document // document is excluded
+}
+```
 
 
 ### Datetime constraints


### PR DESCRIPTION
/!\ This work was AI generated, do not trust me blindly 

The `@structurePattern` trait now supports targeting unions in addition to structures. When the target is a union, the pattern must use the magic identifiers `{label}` (discriminator) and `{value}` (payload), and all union members must target simple shapes (excluding document).

Changes:
- Widen `@idRef` selector in `string.smithy` to accept unions
- Refactor validator to dispatch on target shape type (structure vs union)
- Add union-specific validation (magic identifiers, simple member targets)
- Exclude document shapes from valid member targets (structures and unions)
- Fix latent bug in `getParamNamesInPattern` that returned both full match and capture group
- Add 5 new test cases covering union validation
- Update documentation